### PR TITLE
Next.js integration: nextjs subpath + debug-next-dev CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,161 @@ Occassionally, you would want to only turn on namespaces for latest code changes
 DEBUG=namespace:with:latest-code-changes*
 ```
 
+## Next.js
+
+`debug-next/nextjs` captures errors from every Next.js error surface
+(server runtime, client runtime, React render boundary, dev-server
+output) and writes them verbatim to `<repo-root>/.debug-next/<appName>.log`.
+The file is a faithful mirror of what scrolls by in the developer's
+terminal — same format, same content, ANSI codes stripped. The AI
+copilot reads the file the same way it would read the terminal.
+
+### Install
+
+```bash
+npm install --save debug-next
+# or
+yarn add debug-next
+# or
+bun add debug-next
+```
+
+### 1. Server runtime — `instrumentation.ts`
+
+Hook the LogBase file-writer on Node startup and replace `onRequestError`
+with one that persists to the log file. Composes with Sentry if present:
+
+```ts
+// src/instrumentation.ts
+import * as Sentry from '@sentry/nextjs'
+import { attachFileWriter, createOnRequestError } from 'debug-next/nextjs'
+
+export async function register() {
+    if (process.env.NEXT_RUNTIME === 'nodejs') {
+        await import('../sentry.server.config') // if you use Sentry
+        attachFileWriter({ appName: 'my-app' })
+    }
+}
+
+export const onRequestError = createOnRequestError({
+    appName: 'my-app',
+    sentry: Sentry.captureRequestError, // optional
+})
+```
+
+### 2. Client runtime — `instrumentation-client.ts`
+
+Install `window.onerror` and `unhandledrejection` listeners that POST to
+the route handler set up in step 3:
+
+```ts
+// src/instrumentation-client.ts
+import { registerClientCapture } from 'debug-next/nextjs/client'
+
+registerClientCapture({ appName: 'my-app' })
+```
+
+### 3. Receiving endpoint — `app/api/_debug-next/route.ts`
+
+```ts
+// src/app/api/_debug-next/route.ts
+import { createDebugNextRoute } from 'debug-next/nextjs/route'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export const { POST } = createDebugNextRoute({ appName: 'my-app' })
+```
+
+### 4. React render boundary — `global-error.tsx` (optional)
+
+```tsx
+// app/global-error.tsx (or src/app/global-error.tsx if using the src/ layout)
+'use client'
+import { reportClientEvent } from 'debug-next/nextjs/client'
+import { useEffect } from 'react'
+
+export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
+    useEffect(() => {
+        reportClientEvent('/api/_debug-next', {
+            appName: 'my-app',
+            source: 'global-error',
+            message: error.message,
+            stack: error.stack,
+            digest: error.digest,
+        })
+    }, [error])
+    // ...render fallback
+}
+```
+
+### 5. Dev-server build errors — `package.json`
+
+Wrap the dev command with `debug-next-dev` to capture Turbopack/webpack
+compile errors:
+
+```jsonc
+{
+    "scripts": {
+        "dev": "debug-next-dev -- next dev"
+    }
+}
+```
+
+### Log output
+
+Raw stream at `<repo-root>/.debug-next/<appName>.log`. The CLI tees the
+wrapped command's stdout/stderr verbatim. `LogBase` hooks and
+synthesized events (Next.js `onRequestError`, client error reports) emit
+terminal-style lines into the same file:
+
+```
+[2026-05-26T10:33:21.482Z] [debug-next-dev] wrapping: next dev
+  ✓ Ready in 2.1s
+[2026-05-26T10:33:22.001Z] [my-app] log src:workers:init: Worker started
+[2026-05-26T10:33:25.910Z] [my-app] logError handleCheckout: Snag: Stripe charge failed
+    at handleCheckout (/app/api/checkout/route.ts:42:15)
+    at ... {
+  breadcrumbs: [ { stage: 'checkout' }, { userId: 'u_123' } ],
+  info: { amount: 4200, currency: 'usd' }
+}
+[2026-05-26T10:33:26.013Z] [my-app] logError route — POST /api/checkout
+Error: Stripe charge failed
+    at handleCheckout (/app/api/checkout/route.ts:42:15)
+    at ...
+```
+
+Errors are rendered with `util.inspect`, so custom Error subclasses
+(e.g. Snag's `breadcrumbs` / `info`) appear in the file instead of being
+flattened to `err.stack`. The CLI also truncates the file at startup, so
+each `bun run dev` begins from a clean slate.
+
+### Session vs. history
+
+`attachFileWriter` and the `debug-next-dev` CLI both truncate
+`<appName>.log` once per process by default — every restart starts
+fresh. Hot reloads inside a running process don't re-truncate (a
+module-level Set tracks "already cleared this process"), so in-session
+events aren't wiped.
+
+If you'd rather accumulate logs across restarts (e.g. to grep across
+yesterday's debug session), pass `resetOnStart: false`:
+
+```ts
+attachFileWriter({ appName: 'my-app', resetOnStart: false })
+```
+
+### Env overrides
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DEBUG_NEXT_APP_NAME` | `package.json#name` (CLI only) | Override app name |
+| `DEBUG_NEXT_LOG_DIR` | `<repo-root>/.debug-next` | Where log files are written |
+| `DEBUG_NEXT_DISABLE` | unset | Set to `"true"` to disable file writes |
+| `DEBUG_NEXT_FORCE` | unset | Required to enable file writes when `NODE_ENV=production` (disk logging is off by default in prod) |
+
+Add `.debug-next/` to your `.gitignore`.
+
 ## Roadmap:
 
-1. Browser compatibility.
-2. Support Winston transportation methodology.
-3. Out-of-box support for Sentry.
+1. Out-of-box support for Sentry.

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ short-circuits when `NODE_ENV=production`:
 | Surface | Production default |
 |---|---|
 | `attachFileWriter` | `LogBase.init` still runs, but the file-writer hook is not attached |
-| `teeStdStreams` | Returns before wrapping `process.stdout` / `process.stderr` |
+| `pipeStdStreamsToFile` | Returns before wrapping `process.stdout` / `process.stderr` |
 | `createOnRequestError` | `appendRaw` is called but no-ops; Sentry composition still fires |
 | `createDebugNextRoute` POST | **Returns `404`** — the route refuses to parse the body |
 | `registerClientCapture` | Browsers don't install the `window.onerror` / `unhandledrejection` listeners, so no client POSTs are fired |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ registerClientCapture({ appName: 'my-app' })
 ### 3. Receiving endpoint — `app/api/_debug-next/route.ts`
 
 ```ts
-// src/app/api/_debug-next/route.ts
+// app/api/_debug-next/route.ts (or src/app/... with the src/ layout)
 import { createDebugNextRoute } from 'debug-next/nextjs/route'
 
 export const runtime = 'nodejs'
@@ -280,6 +280,16 @@ export const dynamic = 'force-dynamic'
 
 export const { POST } = createDebugNextRoute({ appName: 'my-app' })
 ```
+
+> ⚠️ **Do not enable this endpoint in production.** It's an
+> unauthenticated POST handler (it has to be — the browser fires
+> `window.onerror` without credentials), writes attacker-controllable
+> text into a file your AI session reads, and serves no durable purpose
+> outside the dev loop. The handler short-circuits to `404` whenever
+> `NODE_ENV=production` (unless you opt in with `DEBUG_NEXT_FORCE=true`,
+> which you almost certainly shouldn't). Sentry is the right durable
+> sink for production client errors. See the [Production](#production)
+> section below.
 
 ### 4. React render boundary — `global-error.tsx` (optional)
 
@@ -369,6 +379,36 @@ attachFileWriter({ appName: 'my-app', resetOnStart: false })
 | `DEBUG_NEXT_FORCE` | unset | Required to enable file writes when `NODE_ENV=production` (disk logging is off by default in prod) |
 
 Add `.debug-next/` to your `.gitignore`.
+
+### Production
+
+`debug-next/nextjs` is a **dev-loop tool**. Every write surface
+short-circuits when `NODE_ENV=production`:
+
+| Surface | Production default |
+|---|---|
+| `attachFileWriter` | `LogBase.init` still runs, but the file-writer hook is not attached |
+| `teeStdStreams` | Returns before wrapping `process.stdout` / `process.stderr` |
+| `createOnRequestError` | `appendRaw` is called but no-ops; Sentry composition still fires |
+| `createDebugNextRoute` POST | **Returns `404`** — the route refuses to parse the body |
+| `registerClientCapture` | Browsers don't install the `window.onerror` / `unhandledrejection` listeners, so no client POSTs are fired |
+
+The `DEBUG_NEXT_FORCE=true` env var re-enables all of the above for
+self-hosted servers that genuinely want disk logs in prod, but think
+hard before flipping it. In particular **never enable the route
+handler in production**:
+
+- The endpoint is unauthenticated (the browser can't send credentials
+  for `window.onerror`).
+- It writes attacker-controlled text into a file the AI copilot reads,
+  which is a prompt-injection vector even with the newline / control-char
+  sanitization applied to incoming fields.
+- On Vercel / serverless, the filesystem is read-only or ephemeral, so
+  the writes silently fail anyway.
+- On self-hosted servers, the file grows without bound — there's no
+  rotation.
+
+Sentry is the right durable sink for production client errors.
 
 ## Roadmap:
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,33 @@
 {
     "name": "debug-next",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "A feature-enhanced TypeScript drop-in replacement for a very popular and simple-to-use debug module.",
     "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": "./dist/index.js",
+        "./nextjs": "./dist/nextjs/server.js",
+        "./nextjs/client": "./dist/nextjs/client.js",
+        "./nextjs/route": "./dist/nextjs/route.js",
+        "./nextjs/*": "./dist/nextjs/*.js",
+        "./dist/*": "./dist/*",
+        "./package.json": "./package.json"
+    },
+    "typesVersions": {
+        "*": {
+            "nextjs": ["./dist/nextjs/server.d.ts"],
+            "nextjs/client": ["./dist/nextjs/client.d.ts"],
+            "nextjs/route": ["./dist/nextjs/route.d.ts"]
+        }
+    },
+    "bin": {
+        "debug-next-dev": "./dist/bin/debug-next-dev.js"
+    },
     "keywords": [
         "debug",
         "log",
-        "debugger"
+        "debugger",
+        "nextjs"
     ],
     "files": [
         "dist",
@@ -18,7 +39,7 @@
         "lint": "yarn lint:build && yarn lint:ci",
         "lint:build": "tsc --project tsconfig.build.json --noEmit",
         "lint:ci": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-        "build": "tsc --project tsconfig.build.json",
+        "build": "tsc --project tsconfig.build.json && chmod +x ./dist/bin/debug-next-dev.js || true",
         "prepublishOnly": "yarn lint:ci && yarn build",
         "tsc": "tsc"
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "lint": "yarn lint:build && yarn lint:ci",
         "lint:build": "tsc --project tsconfig.build.json --noEmit",
         "lint:ci": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-        "build": "tsc --project tsconfig.build.json && chmod +x ./dist/bin/debug-next-dev.js || true",
+        "build": "tsc --project tsconfig.build.json && node ./scripts/postbuild.js",
         "prepublishOnly": "yarn lint:ci && yarn build",
         "tsc": "tsc"
     },

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * Postbuild step for the `debug-next-dev` CLI:
+ *
+ *   1. Prepend `#!/usr/bin/env node` if the compiled file is missing it.
+ *      Some editors/formatters strip shebangs from `.ts` source files,
+ *      which then propagates to the `.js` output and makes the CLI
+ *      unexecutable (the shell tries to interpret it as a script and
+ *      fails on `"use strict";`). This step makes the shebang
+ *      independent of the source file's state.
+ *
+ *   2. `chmod +x` so the `node_modules/.bin/debug-next-dev` symlink
+ *      resolves to an executable target.
+ */
+
+const fs = require('fs')
+
+const target = './dist/bin/debug-next-dev.js'
+const shebang = '#!/usr/bin/env node\n'
+
+if (!fs.existsSync(target)) {
+    // Nothing to do — let the build itself fail loudly if dist is missing.
+    process.exit(0)
+}
+
+const content = fs.readFileSync(target, 'utf-8')
+if (!content.startsWith('#!')) {
+    fs.writeFileSync(target, shebang + content)
+}
+
+fs.chmodSync(target, 0o755)

--- a/src/bin/debug-next-dev.ts
+++ b/src/bin/debug-next-dev.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * CLI wrapper for `next dev` (or any long-running build command). Pipes
  * the child process's stdout/stderr output to `<appName>.log` so the

--- a/src/bin/debug-next-dev.ts
+++ b/src/bin/debug-next-dev.ts
@@ -38,18 +38,21 @@ const USAGE = [
     '',
 ].join('\n')
 
-const log = (msg: string): void => void process.stderr.write(`[debug-next-dev] ${msg}\n`)
+const log = (message: string): void =>
+    void process.stderr.write(`[debug-next-dev] ${message}\n`)
 
-type TParsedArgs = { kind: 'help'; explicit: boolean } | { kind: 'run'; cmd: string[] }
+type TParsedArgs =
+    | { kind: 'help'; explicit: boolean }
+    | { kind: 'run'; command: string[] }
 
 const parseArgs = (argv: string[]): TParsedArgs => {
     if (argv.length === 0) return { kind: 'help', explicit: false }
     if (argv[0] === '-h' || argv[0] === '--help') {
         return { kind: 'help', explicit: true }
     }
-    const cmd = argv[0] === '--' ? argv.slice(1) : argv
-    if (cmd.length === 0) return { kind: 'help', explicit: false }
-    return { kind: 'run', cmd }
+    const command = argv[0] === '--' ? argv.slice(1) : argv
+    if (command.length === 0) return { kind: 'help', explicit: false }
+    return { kind: 'run', command }
 }
 
 /* -------------------------------------------------------------------------- */
@@ -61,9 +64,9 @@ const stripNpmScope = (name: string): string => name.replace(/^@[^/]+\//, '')
 const readPackageName = (cwd: string): string | undefined => {
     try {
         const raw = fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8')
-        const pkg = JSON.parse(raw) as { name?: unknown }
-        if (typeof pkg.name === 'string' && pkg.name.length > 0) {
-            return stripNpmScope(pkg.name)
+        const packageJson = JSON.parse(raw) as { name?: unknown }
+        if (typeof packageJson.name === 'string' && packageJson.name.length > 0) {
+            return stripNpmScope(packageJson.name)
         }
     } catch {
         // fall through
@@ -87,16 +90,16 @@ const wireSignalForwarding = (child: ChildProcess): void => {
     process.on('SIGHUP', () => forward('SIGHUP'))
 }
 
-const teeStream = (
+const pipeStream = (
     stream: NodeJS.ReadableStream | null,
-    sink: NodeJS.WriteStream,
-    writeOpts: { appName: string; logDir?: string },
+    terminalStream: NodeJS.WriteStream,
+    writeOptions: { appName: string; logDir?: string },
 ): void => {
     if (!stream) return
     stream.on('data', (chunk: Buffer) => {
         const text = chunk.toString('utf-8')
-        sink.write(text)
-        appendRaw(text, writeOpts)
+        terminalStream.write(text)
+        appendRaw(text, writeOptions)
     })
     // An unhandled 'error' on a Readable would crash the parent CLI.
     stream.on('error', err => log(`stream error: ${err.message}`))
@@ -114,27 +117,27 @@ const main = (): void => {
     }
 
     const appName = resolveAppName()
-    const logDir = process.env.DEBUG_NEXT_LOG_DIR
-    const writeOpts = { appName, ...(logDir ? { logDir } : {}) }
+    const logDirectory = process.env.DEBUG_NEXT_LOG_DIR
+    const writeOptions = { appName, ...(logDirectory ? { logDir: logDirectory } : {}) }
 
-    resetLogFile(writeOpts)
+    resetLogFile(writeOptions)
     appendRaw(
-        `[${new Date().toISOString()}] [debug-next-dev] wrapping: ${parsed.cmd.join(
+        `[${new Date().toISOString()}] [debug-next-dev] wrapping: ${parsed.command.join(
             ' ',
         )}\n`,
-        writeOpts,
+        writeOptions,
     )
 
-    log(`wrapping: ${parsed.cmd.join(' ')}`)
+    log(`wrapping: ${parsed.command.join(' ')}`)
     log(`app: ${appName}`)
 
-    const child = spawn(parsed.cmd[0], parsed.cmd.slice(1), {
+    const child = spawn(parsed.command[0], parsed.command.slice(1), {
         stdio: ['inherit', 'pipe', 'pipe'],
         env: process.env,
     })
 
-    teeStream(child.stdout, process.stdout, writeOpts)
-    teeStream(child.stderr, process.stderr, writeOpts)
+    pipeStream(child.stdout, process.stdout, writeOptions)
+    pipeStream(child.stderr, process.stderr, writeOptions)
     wireSignalForwarding(child)
 
     child.on('error', err => {

--- a/src/bin/debug-next-dev.ts
+++ b/src/bin/debug-next-dev.ts
@@ -1,0 +1,153 @@
+/**
+ * CLI wrapper for `next dev` (or any long-running build command). Pipes
+ * the child process's stdout/stderr output to `<appName>.log` so the
+ * AI copilot can read exactly what the developer sees in the terminal
+ * and browser console.
+ *
+ *   debug-next-dev -- next dev --turbopack
+ *
+ * The log file is cleared once at startup, so each `bun run dev`
+ * session starts with a clean view.
+ *
+ * Env overrides:
+ *   DEBUG_NEXT_APP_NAME   App name (default: package.json#name)
+ *   DEBUG_NEXT_LOG_DIR    Log directory (default: <repo-root>/.debug-next)
+ *   DEBUG_NEXT_DISABLE    "true" disables file writes
+ */
+
+import { spawn, type ChildProcess } from 'child_process'
+import * as fs from 'fs'
+import * as path from 'path'
+import { appendRaw, resetLogFile } from '../nextjs/file-writer'
+
+/* -------------------------------------------------------------------------- */
+/* CLI surface                                                                 */
+/* -------------------------------------------------------------------------- */
+
+const USAGE = [
+    'Usage: debug-next-dev [--] <command> [args...]',
+    '',
+    'Wraps a Next.js dev/build command, pipes its output to the terminal,',
+    'and writes the same stream verbatim to .debug-next/<appName>.log.',
+    '',
+    'Env:',
+    '  DEBUG_NEXT_APP_NAME   Override app name (default: package.json#name)',
+    '  DEBUG_NEXT_LOG_DIR    Override log directory (default: repo-root/.debug-next)',
+    '  DEBUG_NEXT_DISABLE    Set to "true" to disable writes',
+    '',
+].join('\n')
+
+const log = (msg: string): void => void process.stderr.write(`[debug-next-dev] ${msg}\n`)
+
+type TParsedArgs = { kind: 'help'; explicit: boolean } | { kind: 'run'; cmd: string[] }
+
+const parseArgs = (argv: string[]): TParsedArgs => {
+    if (argv.length === 0) return { kind: 'help', explicit: false }
+    if (argv[0] === '-h' || argv[0] === '--help') {
+        return { kind: 'help', explicit: true }
+    }
+    const cmd = argv[0] === '--' ? argv.slice(1) : argv
+    if (cmd.length === 0) return { kind: 'help', explicit: false }
+    return { kind: 'run', cmd }
+}
+
+/* -------------------------------------------------------------------------- */
+/* App-name discovery                                                          */
+/* -------------------------------------------------------------------------- */
+
+const stripNpmScope = (name: string): string => name.replace(/^@[^/]+\//, '')
+
+const readPackageName = (cwd: string): string | undefined => {
+    try {
+        const raw = fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8')
+        const pkg = JSON.parse(raw) as { name?: unknown }
+        if (typeof pkg.name === 'string' && pkg.name.length > 0) {
+            return stripNpmScope(pkg.name)
+        }
+    } catch {
+        // fall through
+    }
+    return undefined
+}
+
+const resolveAppName = (): string =>
+    process.env.DEBUG_NEXT_APP_NAME ?? readPackageName(process.cwd()) ?? 'app'
+
+/* -------------------------------------------------------------------------- */
+/* Child process orchestration                                                 */
+/* -------------------------------------------------------------------------- */
+
+const wireSignalForwarding = (child: ChildProcess): void => {
+    const forward = (signal: NodeJS.Signals): void => {
+        if (!child.killed) child.kill(signal)
+    }
+    process.on('SIGINT', () => forward('SIGINT'))
+    process.on('SIGTERM', () => forward('SIGTERM'))
+    process.on('SIGHUP', () => forward('SIGHUP'))
+}
+
+const teeStream = (
+    stream: NodeJS.ReadableStream | null,
+    sink: NodeJS.WriteStream,
+    writeOpts: { appName: string; logDir?: string },
+): void => {
+    if (!stream) return
+    stream.on('data', (chunk: Buffer) => {
+        const text = chunk.toString('utf-8')
+        sink.write(text)
+        appendRaw(text, writeOpts)
+    })
+    // An unhandled 'error' on a Readable would crash the parent CLI.
+    stream.on('error', err => log(`stream error: ${err.message}`))
+}
+
+/* -------------------------------------------------------------------------- */
+/* Entry point                                                                 */
+/* -------------------------------------------------------------------------- */
+
+const main = (): void => {
+    const parsed = parseArgs(process.argv.slice(2))
+    if (parsed.kind === 'help') {
+        process.stderr.write(USAGE)
+        process.exit(parsed.explicit ? 0 : 2)
+    }
+
+    const appName = resolveAppName()
+    const logDir = process.env.DEBUG_NEXT_LOG_DIR
+    const writeOpts = { appName, ...(logDir ? { logDir } : {}) }
+
+    resetLogFile(writeOpts)
+    appendRaw(
+        `[${new Date().toISOString()}] [debug-next-dev] wrapping: ${parsed.cmd.join(
+            ' ',
+        )}\n`,
+        writeOpts,
+    )
+
+    log(`wrapping: ${parsed.cmd.join(' ')}`)
+    log(`app: ${appName}`)
+
+    const child = spawn(parsed.cmd[0], parsed.cmd.slice(1), {
+        stdio: ['inherit', 'pipe', 'pipe'],
+        env: process.env,
+    })
+
+    teeStream(child.stdout, process.stdout, writeOpts)
+    teeStream(child.stderr, process.stderr, writeOpts)
+    wireSignalForwarding(child)
+
+    child.on('error', err => {
+        log(`failed to spawn: ${err.message}`)
+        process.exit(1)
+    })
+
+    child.on('exit', (code, signal) => {
+        if (signal) {
+            process.kill(process.pid, signal)
+            return
+        }
+        process.exit(code ?? 0)
+    })
+}
+
+main()

--- a/src/helpers/callerCallsite.ts
+++ b/src/helpers/callerCallsite.ts
@@ -112,7 +112,7 @@ export function callerCallsite({ depth = 0 } = {}) {
                 callers.unshift(callSite)
             }
 
-            const isBunRuntime = !!process.versions.bun
+            const isBunRuntime = typeof process !== 'undefined' && !!process.versions?.bun
 
             // skip the first function in bun runtime (callerCallsite)
             if (isBunRuntime && i === 0) continue

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,7 +248,7 @@ const createLogger = (filenameOrNamespace: string | undefined) => {
             return process.stdout.write(`${formatWithOptions(inspectOpts, ...args)}\n`)
         }
         // eslint-disable-next-line no-console
-        console.log(...args)
+        console.log(formatWithOptions(inspectOpts, ...args))
         return true
     }
     return logger

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,18 @@ const createLogger = (filenameOrNamespace: string | undefined) => {
     // this allow logs to be separated between non-error types (process.stdout) and error types (process.stderr)
     logger.log = (...args) => {
         const inspectOpts = cleanInspectOpts(logger.inspectOpts)
-        return process.stdout.write(`${formatWithOptions(inspectOpts, ...args)}\n`)
+        // In Node, write to stdout directly to keep non-error logs out of stderr.
+        // In non-Node runtimes (browser / edge), `process.stdout` is unavailable;
+        // fall back to console.log so the bundle doesn't crash.
+        if (
+            typeof process !== 'undefined' &&
+            typeof process.stdout?.write === 'function'
+        ) {
+            return process.stdout.write(`${formatWithOptions(inspectOpts, ...args)}\n`)
+        }
+        // eslint-disable-next-line no-console
+        console.log(...args)
+        return true
     }
     return logger
 }

--- a/src/nextjs/client.ts
+++ b/src/nextjs/client.ts
@@ -90,22 +90,22 @@ export const reportClientEvent = (endpoint: string, input: TClientEventInput): v
  * inlines `process.env.NODE_ENV` into client bundles at build time, so
  * this check costs nothing at runtime.
  */
-export const registerClientCapture = (opts: TRegisterClientCaptureOptions): void => {
+export const registerClientCapture = (options: TRegisterClientCaptureOptions): void => {
     if (typeof window === 'undefined') return
     if (typeof process !== 'undefined' && process.env.NODE_ENV === 'production') {
         return
     }
 
-    const endpoint = opts.endpoint ?? '/api/_debug-next'
+    const endpoint = options.endpoint ?? '/api/_debug-next'
     const flag = '__debug_next_capture_installed__'
-    const w = window as unknown as Record<string, unknown>
-    if (w[flag]) return
-    w[flag] = true
+    const windowGlobals = window as unknown as Record<string, unknown>
+    if (windowGlobals[flag]) return
+    windowGlobals[flag] = true
 
     window.addEventListener('error', event => {
         const err = event.error instanceof Error ? event.error : null
         reportClientEvent(endpoint, {
-            appName: opts.appName,
+            appName: options.appName,
             source: 'client-error',
             message: err?.message ?? event.message ?? 'Uncaught error',
             stack: err?.stack,
@@ -122,7 +122,7 @@ export const registerClientCapture = (opts: TRegisterClientCaptureOptions): void
             err?.message ??
             (typeof reason === 'string' ? reason : 'Unhandled promise rejection')
         reportClientEvent(endpoint, {
-            appName: opts.appName,
+            appName: options.appName,
             source: 'client-rejection',
             message,
             stack: err?.stack,

--- a/src/nextjs/client.ts
+++ b/src/nextjs/client.ts
@@ -1,0 +1,132 @@
+/**
+ * Browser-only helpers. Two exports:
+ *
+ *  - `registerClientCapture`: installs `window.onerror` and
+ *    `unhandledrejection` listeners that POST the captured event to the
+ *    debug-next route handler. Idempotent per page.
+ *  - `reportClientEvent`: post a single event manually — used from
+ *    `global-error.tsx` and other React error boundaries.
+ *
+ * Has no Node-only imports, so it's safe to include in any client bundle
+ * (e.g. `instrumentation-client.ts`).
+ */
+
+export type TClientEventInput = {
+    appName: string
+    source: 'client-error' | 'client-rejection' | 'global-error'
+    level?: string
+    message: string
+    stack?: string
+    digest?: string
+    scope?: string | null
+    meta?: unknown[]
+}
+
+export type TRegisterClientCaptureOptions = {
+    appName: string
+    /** Route the browser POSTs error events to. Default: `/api/_debug-next`. */
+    endpoint?: string
+}
+
+const safePost = (endpoint: string, payload: unknown): void => {
+    let body: string
+    try {
+        body = JSON.stringify(payload)
+    } catch {
+        return
+    }
+
+    try {
+        if (
+            typeof navigator !== 'undefined' &&
+            typeof navigator.sendBeacon === 'function'
+        ) {
+            const blob = new Blob([body], { type: 'application/json' })
+            if (navigator.sendBeacon(endpoint, blob)) return
+        }
+    } catch {
+        // fall through to fetch
+    }
+
+    try {
+        void fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body,
+            keepalive: true,
+        })
+    } catch {
+        // swallow — nothing more we can do client-side
+    }
+}
+
+/**
+ * Build the JSON payload sent to the route handler. Exposed so consumers
+ * (e.g. `global-error.tsx`) can construct one directly without going through
+ * the listeners.
+ */
+export const reportClientEvent = (endpoint: string, input: TClientEventInput): void => {
+    safePost(endpoint, {
+        appName: input.appName,
+        source: input.source,
+        level: input.level ?? 'logError',
+        message: input.message,
+        stack: input.stack,
+        digest: input.digest,
+        scope: input.scope ?? null,
+        meta: input.meta,
+        ts: new Date().toISOString(),
+    })
+}
+
+/**
+ * Install global error listeners that forward uncaught errors and unhandled
+ * rejections to the debug-next route handler. Idempotent — safe to call once
+ * per page from `instrumentation-client.ts`.
+ *
+ * No-ops when `process.env.NODE_ENV === 'production'` so production
+ * browsers don't fire pointless POSTs at a server-side route that's
+ * also no-op in prod (the route handler returns 404 there). Next.js
+ * inlines `process.env.NODE_ENV` into client bundles at build time, so
+ * this check costs nothing at runtime.
+ */
+export const registerClientCapture = (opts: TRegisterClientCaptureOptions): void => {
+    if (typeof window === 'undefined') return
+    if (typeof process !== 'undefined' && process.env.NODE_ENV === 'production') {
+        return
+    }
+
+    const endpoint = opts.endpoint ?? '/api/_debug-next'
+    const flag = '__debug_next_capture_installed__'
+    const w = window as unknown as Record<string, unknown>
+    if (w[flag]) return
+    w[flag] = true
+
+    window.addEventListener('error', event => {
+        const err = event.error instanceof Error ? event.error : null
+        reportClientEvent(endpoint, {
+            appName: opts.appName,
+            source: 'client-error',
+            message: err?.message ?? event.message ?? 'Uncaught error',
+            stack: err?.stack,
+            scope: event.filename
+                ? `${event.filename}:${event.lineno ?? 0}:${event.colno ?? 0}`
+                : null,
+        })
+    })
+
+    window.addEventListener('unhandledrejection', event => {
+        const reason = event.reason
+        const err = reason instanceof Error ? reason : null
+        const message =
+            err?.message ??
+            (typeof reason === 'string' ? reason : 'Unhandled promise rejection')
+        reportClientEvent(endpoint, {
+            appName: opts.appName,
+            source: 'client-rejection',
+            message,
+            stack: err?.stack,
+            meta: err ? undefined : [reason],
+        })
+    })
+}

--- a/src/nextjs/file-writer.test.ts
+++ b/src/nextjs/file-writer.test.ts
@@ -1,0 +1,268 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+const TMP_PREFIX = path.join(os.tmpdir(), 'debug-next-fw-')
+
+const freshTmpDir = (): string => fs.mkdtempSync(TMP_PREFIX)
+
+const readLog = (dir: string, appName: string): string =>
+    fs.readFileSync(path.join(dir, `${appName}.log`), 'utf-8')
+
+const cleanEnv = () => {
+    delete process.env.NODE_ENV
+    delete process.env.DEBUG_NEXT_DISABLE
+    delete process.env.DEBUG_NEXT_FORCE
+    delete process.env.DEBUG_NEXT_LOG_DIR
+    delete process.env.NEXT_RUNTIME
+}
+
+const reloadModule = () => {
+    // Module-level state (filesReset, dirsEnsured, logDirByCwd, TEE_FLAG
+    // on streams) needs to be fresh between tests that exercise it.
+    jest.resetModules()
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('./file-writer') as typeof import('./file-writer')
+}
+
+describe('isFileWritingDisabled', () => {
+    beforeEach(cleanEnv)
+    afterAll(cleanEnv)
+
+    it('returns false in development with no flags', () => {
+        const { isFileWritingDisabled } = reloadModule()
+        expect(isFileWritingDisabled()).toBe(false)
+    })
+
+    it('returns true when DEBUG_NEXT_DISABLE=true', () => {
+        process.env.DEBUG_NEXT_DISABLE = 'true'
+        const { isFileWritingDisabled } = reloadModule()
+        expect(isFileWritingDisabled()).toBe(true)
+    })
+
+    it('returns true on the edge runtime', () => {
+        process.env.NEXT_RUNTIME = 'edge'
+        const { isFileWritingDisabled } = reloadModule()
+        expect(isFileWritingDisabled()).toBe(true)
+    })
+
+    it('returns true in production by default', () => {
+        process.env.NODE_ENV = 'production'
+        const { isFileWritingDisabled } = reloadModule()
+        expect(isFileWritingDisabled()).toBe(true)
+    })
+
+    it('returns false in production when DEBUG_NEXT_FORCE=true', () => {
+        process.env.NODE_ENV = 'production'
+        process.env.DEBUG_NEXT_FORCE = 'true'
+        const { isFileWritingDisabled } = reloadModule()
+        expect(isFileWritingDisabled()).toBe(false)
+    })
+
+    it('respects DEBUG_NEXT_DISABLE over DEBUG_NEXT_FORCE', () => {
+        process.env.NODE_ENV = 'production'
+        process.env.DEBUG_NEXT_FORCE = 'true'
+        process.env.DEBUG_NEXT_DISABLE = 'true'
+        const { isFileWritingDisabled } = reloadModule()
+        expect(isFileWritingDisabled()).toBe(true)
+    })
+})
+
+describe('appendRaw', () => {
+    let logDir: string
+
+    beforeEach(() => {
+        cleanEnv()
+        logDir = freshTmpDir()
+        process.env.DEBUG_NEXT_LOG_DIR = logDir
+    })
+
+    it('creates the log directory and writes text verbatim', () => {
+        const { appendRaw } = reloadModule()
+        appendRaw('hello world\n', { appName: 'app' })
+        expect(readLog(logDir, 'app')).toBe('hello world\n')
+    })
+
+    it('strips ANSI escape codes', () => {
+        const { appendRaw } = reloadModule()
+        appendRaw('\x1b[31mred\x1b[0m text\n', { appName: 'app' })
+        expect(readLog(logDir, 'app')).toBe('red text\n')
+    })
+
+    it('appends across multiple calls', () => {
+        const { appendRaw } = reloadModule()
+        appendRaw('first\n', { appName: 'app' })
+        appendRaw('second\n', { appName: 'app' })
+        expect(readLog(logDir, 'app')).toBe('first\nsecond\n')
+    })
+
+    it('no-ops in production without DEBUG_NEXT_FORCE', () => {
+        process.env.NODE_ENV = 'production'
+        const { appendRaw } = reloadModule()
+        appendRaw('should not appear\n', { appName: 'app' })
+        expect(fs.existsSync(path.join(logDir, 'app.log'))).toBe(false)
+    })
+})
+
+describe('resetLogFile', () => {
+    let logDir: string
+
+    beforeEach(() => {
+        cleanEnv()
+        logDir = freshTmpDir()
+        process.env.DEBUG_NEXT_LOG_DIR = logDir
+    })
+
+    it('truncates an existing file', () => {
+        const { appendRaw, resetLogFile } = reloadModule()
+        appendRaw('stale data\n', { appName: 'app' })
+        resetLogFile({ appName: 'app' })
+        appendRaw('fresh\n', { appName: 'app' })
+        expect(readLog(logDir, 'app')).toBe('fresh\n')
+    })
+
+    it('is idempotent within a process (does not wipe mid-session events)', () => {
+        const fw = reloadModule()
+        fw.resetLogFile({ appName: 'app' }) // first call truncates
+        fw.appendRaw('event-1\n', { appName: 'app' })
+        fw.resetLogFile({ appName: 'app' }) // second call is a no-op
+        fw.appendRaw('event-2\n', { appName: 'app' })
+        expect(readLog(logDir, 'app')).toBe('event-1\nevent-2\n')
+    })
+})
+
+describe('createFileWriterHook', () => {
+    let logDir: string
+
+    beforeEach(() => {
+        cleanEnv()
+        logDir = freshTmpDir()
+        process.env.DEBUG_NEXT_LOG_DIR = logDir
+    })
+
+    it('produces a single line per call with ISO timestamp + app + level + scope', () => {
+        const { createFileWriterHook } = reloadModule()
+        const hook = createFileWriterHook({ appName: 'app' })
+        hook(['hello'], 'log', true, 'fnScope', 'hook-name')
+        const out = readLog(logDir, 'app')
+        expect(out).toMatch(
+            /^\[\d{4}-\d{2}-\d{2}T[^\]]+\] \[app\] log fnScope: 'hello'\n$/,
+        )
+    })
+
+    it('omits scope from the tag when null', () => {
+        const { createFileWriterHook } = reloadModule()
+        const hook = createFileWriterHook({ appName: 'app' })
+        hook(['no scope'], 'log', true, null, 'hook-name')
+        expect(readLog(logDir, 'app')).toMatch(/\[app\] log: 'no scope'\n$/)
+    })
+
+    it('inspects Error subclasses so custom enumerable props (Snag.breadcrumbs) survive', () => {
+        const { createFileWriterHook } = reloadModule()
+        const hook = createFileWriterHook({ appName: 'app' })
+
+        class Snag extends Error {
+            breadcrumbs: unknown[]
+            constructor(msg: string, breadcrumbs: unknown[]) {
+                super(msg)
+                this.name = 'Snag'
+                this.breadcrumbs = breadcrumbs
+            }
+        }
+        const err = new Snag('boom', [{ step: 'checkout' }])
+        hook([err], 'logError', true, 'handler', 'hook-name')
+
+        const out = readLog(logDir, 'app')
+        expect(out).toContain('Snag: boom')
+        expect(out).toContain("breadcrumbs: [ { step: 'checkout' } ]")
+    })
+})
+
+describe('teeStdStreams', () => {
+    let logDir: string
+    let originalStdout: typeof process.stdout.write
+    let originalStderr: typeof process.stderr.write
+    const TEE_FLAG = Symbol.for('debug-next/tee-installed')
+
+    beforeEach(() => {
+        cleanEnv()
+        logDir = freshTmpDir()
+        process.env.DEBUG_NEXT_LOG_DIR = logDir
+        originalStdout = process.stdout.write
+        originalStderr = process.stderr.write
+        // Force-reset the TEE_FLAG so each test starts from a clean wrap.
+        const out = process.stdout as unknown as Record<symbol, unknown>
+        const err = process.stderr as unknown as Record<symbol, unknown>
+        delete out[TEE_FLAG]
+        delete err[TEE_FLAG]
+        // Silence stdout/stderr for the duration of the test — our wrap
+        // delegates to whatever `write` was at wrap time, so swapping in a
+        // no-op here keeps the file write path live while sparing the
+        // test runner's terminal from large test payloads.
+        const noop = (() => true) as typeof process.stdout.write
+        process.stdout.write = noop
+        process.stderr.write = noop
+    })
+
+    afterEach(() => {
+        process.stdout.write = originalStdout
+        process.stderr.write = originalStderr
+        const out = process.stdout as unknown as Record<symbol, unknown>
+        const err = process.stderr as unknown as Record<symbol, unknown>
+        delete out[TEE_FLAG]
+        delete err[TEE_FLAG]
+    })
+
+    it('prepends an ISO timestamp to every complete line', () => {
+        const { teeStdStreams } = reloadModule()
+        teeStdStreams({ appName: 'app' })
+        process.stdout.write('first line\n')
+        process.stdout.write('second line\n')
+        const lines = readLog(logDir, 'app').trim().split('\n')
+        expect(lines).toHaveLength(2)
+        expect(lines[0]).toMatch(/^\[\d{4}-\d{2}-\d{2}T[^\]]+\] first line$/)
+        expect(lines[1]).toMatch(/^\[\d{4}-\d{2}-\d{2}T[^\]]+\] second line$/)
+    })
+
+    it('joins a chunked write into one stamped line once the newline arrives', () => {
+        const { teeStdStreams } = reloadModule()
+        teeStdStreams({ appName: 'app' })
+        // Two writes split mid-line — should appear as a single stamped
+        // line, not two. (We can't reliably check that nothing was
+        // flushed between the writes because Jest's reporter shares the
+        // wrapped stdout and may flush its own newlines in between; what
+        // we care about is that the partial and completing chunks
+        // belong to the same logical line.)
+        process.stdout.write('partial ')
+        process.stdout.write('line completed\n')
+        const out = readLog(logDir, 'app')
+        expect(out).toMatch(/\[[^\]]+\] partial line completed\n/)
+    })
+
+    it('force-flushes an oversized partial line so pending cannot grow without bound', () => {
+        const { teeStdStreams } = reloadModule()
+        teeStdStreams({ appName: 'app' })
+        // 6 MB of newline-free output exceeds the 5 MB MAX_PENDING_BYTES cap.
+        process.stdout.write('x'.repeat(6 * 1024 * 1024))
+        const stat = fs.statSync(path.join(logDir, 'app.log'))
+        expect(stat.size).toBeGreaterThan(5 * 1024 * 1024)
+    })
+
+    it('is idempotent — calling twice in one process does not double-wrap', () => {
+        const { teeStdStreams } = reloadModule()
+        teeStdStreams({ appName: 'app' })
+        teeStdStreams({ appName: 'app' })
+        process.stdout.write('once\n')
+        const out = readLog(logDir, 'app')
+        // If double-wrapped, we'd see two timestamped copies of "once".
+        expect(out.match(/once/g) ?? []).toHaveLength(1)
+    })
+
+    it('no-ops in production without DEBUG_NEXT_FORCE', () => {
+        process.env.NODE_ENV = 'production'
+        const { teeStdStreams } = reloadModule()
+        teeStdStreams({ appName: 'app' })
+        process.stdout.write('should not be teed\n')
+        expect(fs.existsSync(path.join(logDir, 'app.log'))).toBe(false)
+    })
+})

--- a/src/nextjs/file-writer.test.ts
+++ b/src/nextjs/file-writer.test.ts
@@ -18,7 +18,7 @@ const cleanEnv = () => {
 }
 
 const reloadModule = () => {
-    // Module-level state (filesReset, dirsEnsured, logDirByCwd, TEE_FLAG
+    // Module-level state (filesReset, dirsEnsured, logDirByCwd, PIPE_FLAG
     // on streams) needs to be fresh between tests that exercise it.
     jest.resetModules()
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -178,11 +178,11 @@ describe('createFileWriterHook', () => {
     })
 })
 
-describe('teeStdStreams', () => {
+describe('pipeStdStreamsToFile', () => {
     let logDir: string
     let originalStdout: typeof process.stdout.write
     let originalStderr: typeof process.stderr.write
-    const TEE_FLAG = Symbol.for('debug-next/tee-installed')
+    const PIPE_FLAG = Symbol.for('debug-next/pipe-to-file-installed')
 
     beforeEach(() => {
         cleanEnv()
@@ -190,11 +190,11 @@ describe('teeStdStreams', () => {
         process.env.DEBUG_NEXT_LOG_DIR = logDir
         originalStdout = process.stdout.write
         originalStderr = process.stderr.write
-        // Force-reset the TEE_FLAG so each test starts from a clean wrap.
+        // Force-reset the PIPE_FLAG so each test starts from a clean wrap.
         const out = process.stdout as unknown as Record<symbol, unknown>
         const err = process.stderr as unknown as Record<symbol, unknown>
-        delete out[TEE_FLAG]
-        delete err[TEE_FLAG]
+        delete out[PIPE_FLAG]
+        delete err[PIPE_FLAG]
         // Silence stdout/stderr for the duration of the test — our wrap
         // delegates to whatever `write` was at wrap time, so swapping in a
         // no-op here keeps the file write path live while sparing the
@@ -209,13 +209,13 @@ describe('teeStdStreams', () => {
         process.stderr.write = originalStderr
         const out = process.stdout as unknown as Record<symbol, unknown>
         const err = process.stderr as unknown as Record<symbol, unknown>
-        delete out[TEE_FLAG]
-        delete err[TEE_FLAG]
+        delete out[PIPE_FLAG]
+        delete err[PIPE_FLAG]
     })
 
     it('prepends an ISO timestamp to every complete line', () => {
-        const { teeStdStreams } = reloadModule()
-        teeStdStreams({ appName: 'app' })
+        const { pipeStdStreamsToFile } = reloadModule()
+        pipeStdStreamsToFile({ appName: 'app' })
         process.stdout.write('first line\n')
         process.stdout.write('second line\n')
         const lines = readLog(logDir, 'app').trim().split('\n')
@@ -225,8 +225,8 @@ describe('teeStdStreams', () => {
     })
 
     it('joins a chunked write into one stamped line once the newline arrives', () => {
-        const { teeStdStreams } = reloadModule()
-        teeStdStreams({ appName: 'app' })
+        const { pipeStdStreamsToFile } = reloadModule()
+        pipeStdStreamsToFile({ appName: 'app' })
         // Two writes split mid-line — should appear as a single stamped
         // line, not two. (We can't reliably check that nothing was
         // flushed between the writes because Jest's reporter shares the
@@ -240,8 +240,8 @@ describe('teeStdStreams', () => {
     })
 
     it('force-flushes an oversized partial line so pending cannot grow without bound', () => {
-        const { teeStdStreams } = reloadModule()
-        teeStdStreams({ appName: 'app' })
+        const { pipeStdStreamsToFile } = reloadModule()
+        pipeStdStreamsToFile({ appName: 'app' })
         // 6 MB of newline-free output exceeds the 5 MB MAX_PENDING_BYTES cap.
         process.stdout.write('x'.repeat(6 * 1024 * 1024))
         const stat = fs.statSync(path.join(logDir, 'app.log'))
@@ -249,9 +249,9 @@ describe('teeStdStreams', () => {
     })
 
     it('is idempotent — calling twice in one process does not double-wrap', () => {
-        const { teeStdStreams } = reloadModule()
-        teeStdStreams({ appName: 'app' })
-        teeStdStreams({ appName: 'app' })
+        const { pipeStdStreamsToFile } = reloadModule()
+        pipeStdStreamsToFile({ appName: 'app' })
+        pipeStdStreamsToFile({ appName: 'app' })
         process.stdout.write('once\n')
         const out = readLog(logDir, 'app')
         // If double-wrapped, we'd see two timestamped copies of "once".
@@ -260,8 +260,8 @@ describe('teeStdStreams', () => {
 
     it('no-ops in production without DEBUG_NEXT_FORCE', () => {
         process.env.NODE_ENV = 'production'
-        const { teeStdStreams } = reloadModule()
-        teeStdStreams({ appName: 'app' })
+        const { pipeStdStreamsToFile } = reloadModule()
+        pipeStdStreamsToFile({ appName: 'app' })
         process.stdout.write('should not be teed\n')
         expect(fs.existsSync(path.join(logDir, 'app.log'))).toBe(false)
     })

--- a/src/nextjs/file-writer.ts
+++ b/src/nextjs/file-writer.ts
@@ -6,13 +6,13 @@
  *
  * Three public APIs:
  *
- *  - `appendRaw(text, opts)`: append a string verbatim (after ANSI
- *    strip). Used by the CLI to tee child stdout/stderr to disk and by
+ *  - `appendRaw(text, options)`: append a string verbatim (after ANSI
+ *    strip). Used by the CLI to mirror child stdout/stderr to disk and by
  *    the server/route helpers to emit synthesized lines.
- *  - `resetLogFile(opts)`: truncate the log file. Idempotent per
+ *  - `resetLogFile(options)`: truncate the log file. Idempotent per
  *    process via a module-level Set, so hot reloads don't keep
  *    clobbering mid-session content.
- *  - `createFileWriterHook(opts)`: returns a `LogBase` hook that writes
+ *  - `createFileWriterHook(options)`: returns a `LogBase` hook that writes
  *    one terminal-style line per log call.
  */
 
@@ -28,24 +28,24 @@ export type TFileWriterOptions = {
 
 // Keyed by cwd so a process that changes directory mid-run (rare, but
 // possible inside test harnesses or scripts) still resolves correctly.
-const logDirByCwd = new Map<string, string>()
-const dirsEnsured = new Set<string>()
+const logDirectoryByCwd = new Map<string, string>()
+const directoriesEnsured = new Set<string>()
 const filesReset = new Set<string>()
 
 const REPO_ROOT_WALK_MAX = 20
 const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g
 
 const findRepoRoot = (start: string): string => {
-    let cur = start
-    for (let i = 0; i < REPO_ROOT_WALK_MAX; i++) {
+    let currentDir = start
+    for (let depth = 0; depth < REPO_ROOT_WALK_MAX; depth++) {
         try {
-            if (fs.existsSync(path.join(cur, '.git'))) return cur
+            if (fs.existsSync(path.join(currentDir, '.git'))) return currentDir
         } catch {
             // ignore — fall through to next parent
         }
-        const parent = path.dirname(cur)
-        if (parent === cur) break
-        cur = parent
+        const parent = path.dirname(currentDir)
+        if (parent === currentDir) break
+        currentDir = parent
     }
     return start
 }
@@ -61,10 +61,10 @@ export const resolveLogDir = (override?: string): string => {
     if (override) return override
     if (process.env.DEBUG_NEXT_LOG_DIR) return process.env.DEBUG_NEXT_LOG_DIR
     const cwd = process.cwd()
-    const cached = logDirByCwd.get(cwd)
+    const cached = logDirectoryByCwd.get(cwd)
     if (cached) return cached
     const resolved = path.join(findRepoRoot(cwd), '.debug-next')
-    logDirByCwd.set(cwd, resolved)
+    logDirectoryByCwd.set(cwd, resolved)
     return resolved
 }
 
@@ -83,25 +83,25 @@ export const isFileWritingDisabled = (): boolean => {
     return false
 }
 
-const logFilePath = (opts: TFileWriterOptions): string =>
-    path.join(resolveLogDir(opts.logDir), `${opts.appName}.log`)
+const logFilePath = (options: TFileWriterOptions): string =>
+    path.join(resolveLogDir(options.logDir), `${options.appName}.log`)
 
-const ensureDir = (dir: string): void => {
-    if (dirsEnsured.has(dir)) return
-    fs.mkdirSync(dir, { recursive: true })
-    dirsEnsured.add(dir)
+const ensureDirectory = (directory: string): void => {
+    if (directoriesEnsured.has(directory)) return
+    fs.mkdirSync(directory, { recursive: true })
+    directoriesEnsured.add(directory)
 }
 
 /**
  * Append raw text to the app's log file. ANSI escape codes are stripped.
  * Never throws.
  */
-export const appendRaw = (text: string, opts: TFileWriterOptions): void => {
+export const appendRaw = (text: string, options: TFileWriterOptions): void => {
     if (isFileWritingDisabled()) return
-    const fp = logFilePath(opts)
+    const filePath = logFilePath(options)
     try {
-        ensureDir(path.dirname(fp))
-        fs.appendFileSync(fp, text.replace(ANSI_RE, ''))
+        ensureDirectory(path.dirname(filePath))
+        fs.appendFileSync(filePath, text.replace(ANSI_RE, ''))
     } catch {
         // hook must never throw
     }
@@ -112,14 +112,14 @@ export const appendRaw = (text: string, opts: TFileWriterOptions): void => {
  * second call from the same Node process (e.g. after a hot reload) is a
  * no-op, so in-session events aren't wiped.
  */
-export const resetLogFile = (opts: TFileWriterOptions): void => {
+export const resetLogFile = (options: TFileWriterOptions): void => {
     if (isFileWritingDisabled()) return
-    const fp = logFilePath(opts)
-    if (filesReset.has(fp)) return
+    const filePath = logFilePath(options)
+    if (filesReset.has(filePath)) return
     try {
-        ensureDir(path.dirname(fp))
-        fs.writeFileSync(fp, '')
-        filesReset.add(fp)
+        ensureDirectory(path.dirname(filePath))
+        fs.writeFileSync(filePath, '')
+        filesReset.add(filePath)
     } catch {
         // best effort
     }
@@ -147,16 +147,16 @@ export type TPipeStdStreamsToFileOptions = TFileWriterOptions & {
  *
  * Idempotent across hot reloads via a symbol on the stream object.
  */
-export const pipeStdStreamsToFile = (opts: TPipeStdStreamsToFileOptions): void => {
+export const pipeStdStreamsToFile = (options: TPipeStdStreamsToFileOptions): void => {
     if (isFileWritingDisabled()) return
 
-    if (opts.resetOnStart !== false) {
-        resetLogFile({ appName: opts.appName, logDir: opts.logDir })
+    if (options.resetOnStart !== false) {
+        resetLogFile({ appName: options.appName, logDir: options.logDir })
     }
 
-    const writeOpts: TFileWriterOptions = {
-        appName: opts.appName,
-        ...(opts.logDir ? { logDir: opts.logDir } : {}),
+    const writeOptions: TFileWriterOptions = {
+        appName: options.appName,
+        ...(options.logDir ? { logDir: options.logDir } : {}),
     }
 
     const wrap = (stream: TWrappedStream): void => {
@@ -167,7 +167,7 @@ export const pipeStdStreamsToFile = (opts: TPipeStdStreamsToFileOptions): void =
         // when a write is chunked.
         let pending = ''
 
-        stream.write = function teedWrite(
+        stream.write = function pipedWrite(
             chunk: string | Uint8Array,
             ...rest: unknown[]
         ): boolean {
@@ -184,18 +184,21 @@ export const pipeStdStreamsToFile = (opts: TPipeStdStreamsToFileOptions): void =
                     if (newlineAt >= 0) {
                         const completeLines = pending.slice(0, newlineAt)
                         pending = pending.slice(newlineAt + 1)
-                        const ts = new Date().toISOString()
+                        const timestamp = new Date().toISOString()
                         const stamped = completeLines
                             .split('\n')
-                            .map(line => `[${ts}] ${line}`)
+                            .map(line => `[${timestamp}] ${line}`)
                             .join('\n')
-                        appendRaw(`${stamped}\n`, writeOpts)
+                        appendRaw(`${stamped}\n`, writeOptions)
                     }
                     // Force-flush an oversized partial line so a long
                     // newline-less stream (binary dump, single-line JSON
                     // blob) can't grow `pending` without bound.
                     if (pending.length > MAX_PENDING_BYTES) {
-                        appendRaw(`[${new Date().toISOString()}] ${pending}\n`, writeOpts)
+                        appendRaw(
+                            `[${new Date().toISOString()}] ${pending}\n`,
+                            writeOptions,
+                        )
                         pending = ''
                     }
                 }
@@ -219,7 +222,7 @@ export const pipeStdStreamsToFile = (opts: TPipeStdStreamsToFileOptions): void =
  * with `util.inspect`, so their enumerable properties (breadcrumbs,
  * info, etc.) appear in the file instead of being silently dropped.
  */
-export const createFileWriterHook = (opts: TFileWriterOptions): TDebugHook => {
+export const createFileWriterHook = (options: TFileWriterOptions): TDebugHook => {
     return (args, level, _isEnabled, scope) => {
         const formatted = inspect(args.length === 1 ? args[0] : args, {
             depth: 4,
@@ -228,8 +231,8 @@ export const createFileWriterHook = (opts: TFileWriterOptions): TDebugHook => {
         })
         const tag = scope ? `${level} ${scope}` : level
         appendRaw(
-            `[${new Date().toISOString()}] [${opts.appName}] ${tag}: ${formatted}\n`,
-            opts,
+            `[${new Date().toISOString()}] [${options.appName}] ${tag}: ${formatted}\n`,
+            options,
         )
     }
 }

--- a/src/nextjs/file-writer.ts
+++ b/src/nextjs/file-writer.ts
@@ -125,12 +125,12 @@ export const resetLogFile = (opts: TFileWriterOptions): void => {
     }
 }
 
-const TEE_FLAG = Symbol.for('debug-next/tee-installed')
+const PIPE_FLAG = Symbol.for('debug-next/pipe-to-file-installed')
 const MAX_PENDING_BYTES = 1_048_576 * 5 // 5 MiB
 
-type TWrappedStream = NodeJS.WriteStream & { [TEE_FLAG]?: true }
+type TWrappedStream = NodeJS.WriteStream & { [PIPE_FLAG]?: true }
 
-export type TTeeStdStreamsOptions = TFileWriterOptions & {
+export type TPipeStdStreamsToFileOptions = TFileWriterOptions & {
     /**
      * Truncate `<appName>.log` once at process startup. Defaults to
      * `true`. Idempotent across hot reloads within the same process.
@@ -147,7 +147,7 @@ export type TTeeStdStreamsOptions = TFileWriterOptions & {
  *
  * Idempotent across hot reloads via a symbol on the stream object.
  */
-export const teeStdStreams = (opts: TTeeStdStreamsOptions): void => {
+export const pipeStdStreamsToFile = (opts: TPipeStdStreamsToFileOptions): void => {
     if (isFileWritingDisabled()) return
 
     if (opts.resetOnStart !== false) {
@@ -160,7 +160,7 @@ export const teeStdStreams = (opts: TTeeStdStreamsOptions): void => {
     }
 
     const wrap = (stream: TWrappedStream): void => {
-        if (stream[TEE_FLAG]) return
+        if (stream[PIPE_FLAG]) return
         const original = stream.write.bind(stream)
         // Per-stream buffer holds the trailing partial line until a
         // newline arrives — so we don't stamp the same logical line twice
@@ -205,7 +205,7 @@ export const teeStdStreams = (opts: TTeeStdStreamsOptions): void => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return (original as any)(chunk, ...rest)
         } as typeof stream.write
-        stream[TEE_FLAG] = true
+        stream[PIPE_FLAG] = true
     }
 
     wrap(process.stdout as TWrappedStream)

--- a/src/nextjs/file-writer.ts
+++ b/src/nextjs/file-writer.ts
@@ -1,0 +1,235 @@
+/**
+ * Persists raw log text to `<logDir>/<appName>.log`. The file is meant
+ * to mirror what a developer sees scrolling by in the terminal — same
+ * format, same content, with ANSI escape codes stripped so the file
+ * stays clean.
+ *
+ * Three public APIs:
+ *
+ *  - `appendRaw(text, opts)`: append a string verbatim (after ANSI
+ *    strip). Used by the CLI to tee child stdout/stderr to disk and by
+ *    the server/route helpers to emit synthesized lines.
+ *  - `resetLogFile(opts)`: truncate the log file. Idempotent per
+ *    process via a module-level Set, so hot reloads don't keep
+ *    clobbering mid-session content.
+ *  - `createFileWriterHook(opts)`: returns a `LogBase` hook that writes
+ *    one terminal-style line per log call.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { inspect } from 'util'
+import type { TDebugHook } from '../index'
+
+export type TFileWriterOptions = {
+    appName: string
+    logDir?: string
+}
+
+// Keyed by cwd so a process that changes directory mid-run (rare, but
+// possible inside test harnesses or scripts) still resolves correctly.
+const logDirByCwd = new Map<string, string>()
+const dirsEnsured = new Set<string>()
+const filesReset = new Set<string>()
+
+const REPO_ROOT_WALK_MAX = 20
+const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g
+
+const findRepoRoot = (start: string): string => {
+    let cur = start
+    for (let i = 0; i < REPO_ROOT_WALK_MAX; i++) {
+        try {
+            if (fs.existsSync(path.join(cur, '.git'))) return cur
+        } catch {
+            // ignore — fall through to next parent
+        }
+        const parent = path.dirname(cur)
+        if (parent === cur) break
+        cur = parent
+    }
+    return start
+}
+
+/**
+ * Resolve the directory the log file lives in. Precedence:
+ *   1. Explicit `override`.
+ *   2. `DEBUG_NEXT_LOG_DIR` env var.
+ *   3. `<repo-root>/.debug-next` (repo root discovered by walking up for `.git`).
+ *   4. `<cwd>/.debug-next` if no `.git` ancestor exists.
+ */
+export const resolveLogDir = (override?: string): string => {
+    if (override) return override
+    if (process.env.DEBUG_NEXT_LOG_DIR) return process.env.DEBUG_NEXT_LOG_DIR
+    const cwd = process.cwd()
+    const cached = logDirByCwd.get(cwd)
+    if (cached) return cached
+    const resolved = path.join(findRepoRoot(cwd), '.debug-next')
+    logDirByCwd.set(cwd, resolved)
+    return resolved
+}
+
+export const isFileWritingDisabled = (): boolean => {
+    if (typeof process === 'undefined') return true
+    if (process.env.DEBUG_NEXT_DISABLE === 'true') return true
+    if (process.env.NEXT_RUNTIME === 'edge') return true
+    // Off by default in production. Self-hosted servers that want
+    // disk logs in prod can opt in with `DEBUG_NEXT_FORCE=true`.
+    if (
+        process.env.NODE_ENV === 'production' &&
+        process.env.DEBUG_NEXT_FORCE !== 'true'
+    ) {
+        return true
+    }
+    return false
+}
+
+const logFilePath = (opts: TFileWriterOptions): string =>
+    path.join(resolveLogDir(opts.logDir), `${opts.appName}.log`)
+
+const ensureDir = (dir: string): void => {
+    if (dirsEnsured.has(dir)) return
+    fs.mkdirSync(dir, { recursive: true })
+    dirsEnsured.add(dir)
+}
+
+/**
+ * Append raw text to the app's log file. ANSI escape codes are stripped.
+ * Never throws.
+ */
+export const appendRaw = (text: string, opts: TFileWriterOptions): void => {
+    if (isFileWritingDisabled()) return
+    const fp = logFilePath(opts)
+    try {
+        ensureDir(path.dirname(fp))
+        fs.appendFileSync(fp, text.replace(ANSI_RE, ''))
+    } catch {
+        // hook must never throw
+    }
+}
+
+/**
+ * Truncate the app's log file. Idempotent within a single process — a
+ * second call from the same Node process (e.g. after a hot reload) is a
+ * no-op, so in-session events aren't wiped.
+ */
+export const resetLogFile = (opts: TFileWriterOptions): void => {
+    if (isFileWritingDisabled()) return
+    const fp = logFilePath(opts)
+    if (filesReset.has(fp)) return
+    try {
+        ensureDir(path.dirname(fp))
+        fs.writeFileSync(fp, '')
+        filesReset.add(fp)
+    } catch {
+        // best effort
+    }
+}
+
+const TEE_FLAG = Symbol.for('debug-next/tee-installed')
+const MAX_PENDING_BYTES = 1_048_576 * 5 // 5 MiB
+
+type TWrappedStream = NodeJS.WriteStream & { [TEE_FLAG]?: true }
+
+export type TTeeStdStreamsOptions = TFileWriterOptions & {
+    /**
+     * Truncate `<appName>.log` once at process startup. Defaults to
+     * `true`. Idempotent across hot reloads within the same process.
+     */
+    resetOnStart?: boolean
+}
+
+/**
+ * Wrap `process.stdout.write` and `process.stderr.write` so every byte
+ * written to the terminal is also appended verbatim (ANSI-stripped) to
+ * `<appName>.log`. Captures everything the developer sees — Express's
+ * morgan output, debug-next's namespaced lines, `console.log`, error
+ * stacks — without needing a `LogBase` hook.
+ *
+ * Idempotent across hot reloads via a symbol on the stream object.
+ */
+export const teeStdStreams = (opts: TTeeStdStreamsOptions): void => {
+    if (isFileWritingDisabled()) return
+
+    if (opts.resetOnStart !== false) {
+        resetLogFile({ appName: opts.appName, logDir: opts.logDir })
+    }
+
+    const writeOpts: TFileWriterOptions = {
+        appName: opts.appName,
+        ...(opts.logDir ? { logDir: opts.logDir } : {}),
+    }
+
+    const wrap = (stream: TWrappedStream): void => {
+        if (stream[TEE_FLAG]) return
+        const original = stream.write.bind(stream)
+        // Per-stream buffer holds the trailing partial line until a
+        // newline arrives — so we don't stamp the same logical line twice
+        // when a write is chunked.
+        let pending = ''
+
+        stream.write = function teedWrite(
+            chunk: string | Uint8Array,
+            ...rest: unknown[]
+        ): boolean {
+            try {
+                const text =
+                    typeof chunk === 'string'
+                        ? chunk
+                        : Buffer.isBuffer(chunk)
+                        ? chunk.toString('utf-8')
+                        : ''
+                if (text) {
+                    pending += text
+                    const newlineAt = pending.lastIndexOf('\n')
+                    if (newlineAt >= 0) {
+                        const completeLines = pending.slice(0, newlineAt)
+                        pending = pending.slice(newlineAt + 1)
+                        const ts = new Date().toISOString()
+                        const stamped = completeLines
+                            .split('\n')
+                            .map(line => `[${ts}] ${line}`)
+                            .join('\n')
+                        appendRaw(`${stamped}\n`, writeOpts)
+                    }
+                    // Force-flush an oversized partial line so a long
+                    // newline-less stream (binary dump, single-line JSON
+                    // blob) can't grow `pending` without bound.
+                    if (pending.length > MAX_PENDING_BYTES) {
+                        appendRaw(`[${new Date().toISOString()}] ${pending}\n`, writeOpts)
+                        pending = ''
+                    }
+                }
+            } catch {
+                // never let a logger break the host
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return (original as any)(chunk, ...rest)
+        } as typeof stream.write
+        stream[TEE_FLAG] = true
+    }
+
+    wrap(process.stdout as TWrappedStream)
+    wrap(process.stderr as TWrappedStream)
+}
+
+/**
+ * Build a `LogBase` hook suitable for `LogBase.attachHook('all', name, hook)`.
+ * Each log call becomes one line in the file, formatted to look like
+ * Node's terminal output. Error subclasses (e.g. Snag) are inspected
+ * with `util.inspect`, so their enumerable properties (breadcrumbs,
+ * info, etc.) appear in the file instead of being silently dropped.
+ */
+export const createFileWriterHook = (opts: TFileWriterOptions): TDebugHook => {
+    return (args, level, _isEnabled, scope) => {
+        const formatted = inspect(args.length === 1 ? args[0] : args, {
+            depth: 4,
+            colors: false,
+            breakLength: 120,
+        })
+        const tag = scope ? `${level} ${scope}` : level
+        appendRaw(
+            `[${new Date().toISOString()}] [${opts.appName}] ${tag}: ${formatted}\n`,
+            opts,
+        )
+    }
+}

--- a/src/nextjs/route.test.ts
+++ b/src/nextjs/route.test.ts
@@ -1,0 +1,234 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+const TMP_PREFIX = path.join(os.tmpdir(), 'debug-next-route-')
+
+const freshTmpDir = (): string => fs.mkdtempSync(TMP_PREFIX)
+
+const readLog = (dir: string, appName: string): string =>
+    fs.readFileSync(path.join(dir, `${appName}.log`), 'utf-8')
+
+const cleanEnv = () => {
+    delete process.env.NODE_ENV
+    delete process.env.DEBUG_NEXT_DISABLE
+    delete process.env.DEBUG_NEXT_FORCE
+    delete process.env.DEBUG_NEXT_LOG_DIR
+    delete process.env.NEXT_RUNTIME
+}
+
+const reloadModule = () => {
+    jest.resetModules()
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('./route') as typeof import('./route')
+}
+
+const post = async (
+    POST: (req: Request) => Promise<Response>,
+    body: unknown,
+): Promise<{ status: number; body: unknown }> => {
+    const res = await POST(
+        new Request('http://x/api/_debug-next', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: typeof body === 'string' ? body : JSON.stringify(body),
+        }),
+    )
+    const text = await res.text()
+    let parsed: unknown = text
+    try {
+        parsed = JSON.parse(text)
+    } catch {
+        // leave as text
+    }
+    return { status: res.status, body: parsed }
+}
+
+describe('createDebugNextRoute — production guard', () => {
+    beforeEach(cleanEnv)
+    afterAll(cleanEnv)
+
+    it('returns 404 in production by default without parsing the body', async () => {
+        const logDir = freshTmpDir()
+        process.env.DEBUG_NEXT_LOG_DIR = logDir
+        process.env.NODE_ENV = 'production'
+        const { createDebugNextRoute } = reloadModule()
+        const { POST } = createDebugNextRoute({ appName: 'app' })
+        const res = await post(POST, {
+            source: 'client-error',
+            message: 'should not be written',
+        })
+        expect(res.status).toBe(404)
+        expect(res.body).toEqual({ error: 'not_found' })
+        expect(fs.existsSync(path.join(logDir, 'app.log'))).toBe(false)
+    })
+
+    it('accepts traffic in production when DEBUG_NEXT_FORCE=true', async () => {
+        const logDir = freshTmpDir()
+        process.env.DEBUG_NEXT_LOG_DIR = logDir
+        process.env.NODE_ENV = 'production'
+        process.env.DEBUG_NEXT_FORCE = 'true'
+        const { createDebugNextRoute } = reloadModule()
+        const { POST } = createDebugNextRoute({ appName: 'app' })
+        const res = await post(POST, {
+            source: 'client-error',
+            message: 'opt-in',
+        })
+        expect(res.status).toBe(200)
+        expect(readLog(logDir, 'app')).toContain('opt-in')
+    })
+})
+
+describe('createDebugNextRoute — request handling', () => {
+    let logDir: string
+    let POST: (req: Request) => Promise<Response>
+
+    beforeEach(() => {
+        cleanEnv()
+        logDir = freshTmpDir()
+        process.env.DEBUG_NEXT_LOG_DIR = logDir
+        const { createDebugNextRoute } = reloadModule()
+        POST = createDebugNextRoute({ appName: 'app' }).POST
+    })
+
+    it('returns 400 invalid_json for non-JSON bodies', async () => {
+        const res = await post(POST, 'not-json{')
+        expect(res.status).toBe(400)
+        expect(res.body).toEqual({ ok: false, error: 'invalid_json' })
+    })
+
+    it('returns 400 invalid_payload for non-object bodies', async () => {
+        const res = await post(POST, 42)
+        expect(res.status).toBe(400)
+        expect(res.body).toEqual({ ok: false, error: 'invalid_payload' })
+    })
+
+    it('writes a valid event with all fields', async () => {
+        const res = await post(POST, {
+            appName: 'browser-side-name',
+            source: 'client-error',
+            message: 'Something broke',
+            stack: 'Error: Something broke\n    at fn (file.ts:10:5)',
+            scope: 'file.ts:10:5',
+            digest: 'abc123',
+            level: 'logError',
+        })
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual({ ok: true })
+        const out = readLog(logDir, 'app')
+        expect(out).toContain('[browser-side-name]')
+        expect(out).toContain('logError client-error file.ts:10:5 digest=abc123')
+        expect(out).toContain('Something broke')
+        expect(out).toContain('Error: Something broke')
+        expect(out).toContain('    at fn (file.ts:10:5)')
+    })
+
+    it('falls back to the route-level appName when payload omits it', async () => {
+        const res = await post(POST, {
+            source: 'client-error',
+            message: 'no app name in payload',
+        })
+        expect(res.status).toBe(200)
+        expect(readLog(logDir, 'app')).toContain('[app]')
+    })
+
+    it('defaults to client-error for unknown source values', async () => {
+        const res = await post(POST, {
+            source: 'something-weird',
+            message: 'msg',
+        })
+        expect(res.status).toBe(200)
+        expect(readLog(logDir, 'app')).toContain('client-error')
+    })
+
+    it('accepts the three allowed sources', async () => {
+        for (const source of ['client-error', 'client-rejection', 'global-error']) {
+            const r = await post(POST, { source, message: `m-${source}` })
+            expect(r.status).toBe(200)
+            expect(readLog(logDir, 'app')).toContain(source)
+        }
+    })
+})
+
+describe('createDebugNextRoute — sanitization', () => {
+    let logDir: string
+    let POST: (req: Request) => Promise<Response>
+
+    beforeEach(() => {
+        cleanEnv()
+        logDir = freshTmpDir()
+        process.env.DEBUG_NEXT_LOG_DIR = logDir
+        const { createDebugNextRoute } = reloadModule()
+        POST = createDebugNextRoute({ appName: 'app' }).POST
+    })
+
+    it('collapses newlines in single-line fields so injected forged log lines stay on one line', async () => {
+        await post(POST, {
+            source: 'client-error',
+            message: 'real\n[2026-01-01T00:00:00.000Z] [evil] FORGED',
+        })
+        const lines = readLog(logDir, 'app').split('\n').filter(Boolean)
+        // The whole rendered event should still occupy a single line:
+        // the injected `\n` was collapsed to a space.
+        const eventLine = lines.find(l => l.includes('real'))
+        expect(eventLine).toBeDefined()
+        expect(eventLine).toMatch(/real \[2026-01-01T00:00:00.000Z\] \[evil\] FORGED/)
+    })
+
+    it('strips ASCII control characters from single-line fields', async () => {
+        await post(POST, {
+            source: 'client-error',
+            message: 'msg',
+            scope: 'a\x00b\x07c\x1bd',
+        })
+        // \x00 (NUL), \x07 (BEL), \x1b (ESC) should all be gone.
+        expect(readLog(logDir, 'app')).toContain('abcd')
+        expect(readLog(logDir, 'app')).not.toMatch(/[\x00\x07\x1b]/)
+    })
+
+    it('preserves newlines and tabs in the stack field', async () => {
+        await post(POST, {
+            source: 'client-error',
+            message: 'm',
+            stack: 'Error: foo\n\tat bar\n\tat baz',
+        })
+        const out = readLog(logDir, 'app')
+        expect(out).toContain('Error: foo\n\tat bar\n\tat baz')
+    })
+
+    it('strips other control chars from the stack while keeping line breaks', async () => {
+        await post(POST, {
+            source: 'client-error',
+            message: 'm',
+            stack: 'line1\x00with-null\nline2\x07with-bel',
+        })
+        const out = readLog(logDir, 'app')
+        expect(out).toContain('line1with-null\nline2with-bel')
+        expect(out).not.toMatch(/[\x00\x07]/)
+    })
+
+    it('caps oversized meta with a truncation marker', async () => {
+        const huge = { blob: 'x'.repeat(20_000) }
+        await post(POST, {
+            source: 'client-error',
+            message: 'm',
+            meta: [huge],
+        })
+        const out = readLog(logDir, 'app')
+        expect(out).toContain('… (truncated)')
+        // Sanity: the rendered meta line shouldn't carry the full 20 KB blob.
+        const metaLine = out.split('\n').find(l => l.startsWith('meta: ')) ?? ''
+        expect(metaLine.length).toBeLessThan(10_000)
+    })
+
+    it('truncates excessively long single-line fields to their per-field cap', async () => {
+        await post(POST, {
+            source: 'client-error',
+            message: 'a'.repeat(10_000),
+        })
+        const out = readLog(logDir, 'app')
+        // message cap is 4000 — we should see ~4000 'a's, not 10000.
+        const longRun = out.match(/a{1000,}/)?.[0] ?? ''
+        expect(longRun.length).toBeLessThanOrEqual(4_000)
+    })
+})

--- a/src/nextjs/route.ts
+++ b/src/nextjs/route.ts
@@ -17,8 +17,8 @@ const jsonResponse = (body: unknown, status = 200): Response =>
         headers: { 'Content-Type': 'application/json' },
     })
 
-const truncate = (s: string, max: number): string =>
-    s.length > max ? s.slice(0, max) : s
+const truncate = (value: string, maxLength: number): string =>
+    value.length > maxLength ? value.slice(0, maxLength) : value
 
 // We drop ASCII control characters from anything the client sends so a
 // malicious payload can't slip terminal escapes, null bytes, or forged
@@ -31,8 +31,8 @@ const LINE_FEED = 0x0a
 const CARRIAGE_RETURN = 0x0d
 const DEL = 0x7f
 
-const isSafeForLog = (ch: string): boolean => {
-    const code = ch.charCodeAt(0)
+const isSafeForLog = (character: string): boolean => {
+    const code = character.charCodeAt(0)
     // Printable ASCII (and any non-ASCII character — emoji, accented
     // letters, CJK, etc.) is fine.
     if (code >= 0x20 && code !== DEL) return true
@@ -40,44 +40,45 @@ const isSafeForLog = (ch: string): boolean => {
     return code === TAB || code === LINE_FEED || code === CARRIAGE_RETURN
 }
 
-const stripUnsafeChars = (s: string): string => {
-    let out = ''
-    for (let i = 0; i < s.length; i++) {
-        const ch = s[i]
-        if (isSafeForLog(ch)) out += ch
+const stripUnsafeChars = (input: string): string => {
+    let sanitized = ''
+    for (let index = 0; index < input.length; index++) {
+        const character = input[index]
+        if (isSafeForLog(character)) sanitized += character
     }
-    return out
+    return sanitized
 }
 
-const collapseLineBreaks = (s: string): string => {
-    let out = ''
-    for (let i = 0; i < s.length; i++) {
-        const ch = s[i]
-        out += ch === '\n' || ch === '\r' ? ' ' : ch
+const collapseLineBreaks = (input: string): string => {
+    let result = ''
+    for (let index = 0; index < input.length; index++) {
+        const character = input[index]
+        result += character === '\n' || character === '\r' ? ' ' : character
     }
-    return out
+    return result
 }
 
 // For headers (message, scope, digest, etc.): also collapse newlines
 // into spaces so an attacker can't inject a forged "[ts] [app] FORGED
 // LINE" entry by sneaking a `\n` into the payload.
-const sanitizeSingleLine = (s: string): string => collapseLineBreaks(stripUnsafeChars(s))
+const sanitizeSingleLine = (input: string): string =>
+    collapseLineBreaks(stripUnsafeChars(input))
 
 // For multi-line fields (stack): keep newlines — a real stack trace
 // spans several lines.
-const sanitizeMultiLine = (s: string): string => stripUnsafeChars(s)
+const sanitizeMultiLine = (input: string): string => stripUnsafeChars(input)
 
-const asSingleLine = (v: unknown, max: number): string | undefined =>
-    typeof v === 'string' ? truncate(sanitizeSingleLine(v), max) : undefined
+const asSingleLine = (value: unknown, maxLength: number): string | undefined =>
+    typeof value === 'string' ? truncate(sanitizeSingleLine(value), maxLength) : undefined
 
-const asMultiLine = (v: unknown, max: number): string | undefined =>
-    typeof v === 'string' ? truncate(sanitizeMultiLine(v), max) : undefined
+const asMultiLine = (value: unknown, maxLength: number): string | undefined =>
+    typeof value === 'string' ? truncate(sanitizeMultiLine(value), maxLength) : undefined
 
 const MAX_META_BYTES = 8_000
-const safeMeta = (m: unknown): string | undefined => {
-    if (!Array.isArray(m) || m.length === 0) return undefined
+const safeMeta = (meta: unknown): string | undefined => {
+    if (!Array.isArray(meta) || meta.length === 0) return undefined
     try {
-        const serialized = JSON.stringify(m)
+        const serialized = JSON.stringify(meta)
         return serialized.length > MAX_META_BYTES
             ? `${serialized.slice(0, MAX_META_BYTES)}… (truncated)`
             : serialized
@@ -102,28 +103,28 @@ type TClientPayload = {
 
 const formatClientEvent = (raw: unknown, fallbackAppName: string): string | null => {
     if (!raw || typeof raw !== 'object') return null
-    const p = raw as TClientPayload
+    const payload = raw as TClientPayload
 
     const source =
-        typeof p.source === 'string' && CLIENT_SOURCES.has(p.source)
-            ? p.source
+        typeof payload.source === 'string' && CLIENT_SOURCES.has(payload.source)
+            ? payload.source
             : 'client-error'
-    const ts = asSingleLine(p.ts, 64) ?? new Date().toISOString()
-    const appName = asSingleLine(p.appName, 128) ?? fallbackAppName
-    const level = asSingleLine(p.level, 32) ?? 'logError'
-    const message = asSingleLine(p.message, 4000) ?? ''
-    const stack = asMultiLine(p.stack, 16_000)
-    const scope = asSingleLine(p.scope, 256)
-    const digest = asSingleLine(p.digest, 256)
+    const timestamp = asSingleLine(payload.ts, 64) ?? new Date().toISOString()
+    const appName = asSingleLine(payload.appName, 128) ?? fallbackAppName
+    const level = asSingleLine(payload.level, 32) ?? 'logError'
+    const message = asSingleLine(payload.message, 4000) ?? ''
+    const stack = asMultiLine(payload.stack, 16_000)
+    const scope = asSingleLine(payload.scope, 256)
+    const digest = asSingleLine(payload.digest, 256)
 
-    const header = [`[${ts}]`, `[${appName}]`, level, source]
+    const header = [`[${timestamp}]`, `[${appName}]`, level, source]
         .concat(scope ? [scope] : [])
         .concat(digest ? [`digest=${digest}`] : [])
         .join(' ')
 
     const lines: string[] = [`${header} — ${message}`]
     if (stack) lines.push(stack)
-    const meta = safeMeta(p.meta)
+    const meta = safeMeta(payload.meta)
     if (meta) lines.push(`meta: ${meta}`)
     return `${lines.join('\n')}\n\n`
 }
@@ -155,7 +156,7 @@ const formatClientEvent = (raw: unknown, fallbackAppName: string): string | null
  * about whether you actually want this. Sentry is the right durable
  * sink for production client errors. `debug-next` is a dev-loop tool.
  */
-export const createDebugNextRoute = (opts: TCreateDebugNextRouteOptions) => {
+export const createDebugNextRoute = (options: TCreateDebugNextRouteOptions) => {
     const POST = async (request: Request): Promise<Response> => {
         // 404 in production (or whenever writes are disabled) so the
         // endpoint doesn't leak its existence and refuses to parse the
@@ -171,12 +172,12 @@ export const createDebugNextRoute = (opts: TCreateDebugNextRouteOptions) => {
             return jsonResponse({ ok: false, error: 'invalid_json' }, 400)
         }
 
-        const formatted = formatClientEvent(body, opts.appName)
+        const formatted = formatClientEvent(body, options.appName)
         if (!formatted) {
             return jsonResponse({ ok: false, error: 'invalid_payload' }, 400)
         }
 
-        appendRaw(formatted, opts)
+        appendRaw(formatted, options)
         return jsonResponse({ ok: true })
     }
 

--- a/src/nextjs/route.ts
+++ b/src/nextjs/route.ts
@@ -1,0 +1,184 @@
+/**
+ * Builds the App Router POST handler that receives client error events
+ * from `registerClientCapture` and appends them to the app's log file
+ * as terminal-style blocks.
+ */
+
+import { appendRaw, isFileWritingDisabled } from './file-writer'
+
+export type TCreateDebugNextRouteOptions = {
+    appName: string
+    logDir?: string
+}
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+    new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    })
+
+const truncate = (s: string, max: number): string =>
+    s.length > max ? s.slice(0, max) : s
+
+// We drop ASCII control characters from anything the client sends so a
+// malicious payload can't slip terminal escapes, null bytes, or forged
+// log entries into the file (which an AI session may read).
+//
+// Three control characters stay because stack traces and code excerpts
+// legitimately need them:
+const TAB = 0x09
+const LINE_FEED = 0x0a
+const CARRIAGE_RETURN = 0x0d
+const DEL = 0x7f
+
+const isSafeForLog = (ch: string): boolean => {
+    const code = ch.charCodeAt(0)
+    // Printable ASCII (and any non-ASCII character — emoji, accented
+    // letters, CJK, etc.) is fine.
+    if (code >= 0x20 && code !== DEL) return true
+    // Below 0x20 we only allow the three whitespace controls.
+    return code === TAB || code === LINE_FEED || code === CARRIAGE_RETURN
+}
+
+const stripUnsafeChars = (s: string): string => {
+    let out = ''
+    for (let i = 0; i < s.length; i++) {
+        const ch = s[i]
+        if (isSafeForLog(ch)) out += ch
+    }
+    return out
+}
+
+const collapseLineBreaks = (s: string): string => {
+    let out = ''
+    for (let i = 0; i < s.length; i++) {
+        const ch = s[i]
+        out += ch === '\n' || ch === '\r' ? ' ' : ch
+    }
+    return out
+}
+
+// For headers (message, scope, digest, etc.): also collapse newlines
+// into spaces so an attacker can't inject a forged "[ts] [app] FORGED
+// LINE" entry by sneaking a `\n` into the payload.
+const sanitizeSingleLine = (s: string): string => collapseLineBreaks(stripUnsafeChars(s))
+
+// For multi-line fields (stack): keep newlines — a real stack trace
+// spans several lines.
+const sanitizeMultiLine = (s: string): string => stripUnsafeChars(s)
+
+const asSingleLine = (v: unknown, max: number): string | undefined =>
+    typeof v === 'string' ? truncate(sanitizeSingleLine(v), max) : undefined
+
+const asMultiLine = (v: unknown, max: number): string | undefined =>
+    typeof v === 'string' ? truncate(sanitizeMultiLine(v), max) : undefined
+
+const MAX_META_BYTES = 8_000
+const safeMeta = (m: unknown): string | undefined => {
+    if (!Array.isArray(m) || m.length === 0) return undefined
+    try {
+        const serialized = JSON.stringify(m)
+        return serialized.length > MAX_META_BYTES
+            ? `${serialized.slice(0, MAX_META_BYTES)}… (truncated)`
+            : serialized
+    } catch {
+        return undefined
+    }
+}
+
+const CLIENT_SOURCES = new Set(['client-error', 'client-rejection', 'global-error'])
+
+type TClientPayload = {
+    appName?: unknown
+    source?: unknown
+    level?: unknown
+    message?: unknown
+    stack?: unknown
+    digest?: unknown
+    scope?: unknown
+    meta?: unknown
+    ts?: unknown
+}
+
+const formatClientEvent = (raw: unknown, fallbackAppName: string): string | null => {
+    if (!raw || typeof raw !== 'object') return null
+    const p = raw as TClientPayload
+
+    const source =
+        typeof p.source === 'string' && CLIENT_SOURCES.has(p.source)
+            ? p.source
+            : 'client-error'
+    const ts = asSingleLine(p.ts, 64) ?? new Date().toISOString()
+    const appName = asSingleLine(p.appName, 128) ?? fallbackAppName
+    const level = asSingleLine(p.level, 32) ?? 'logError'
+    const message = asSingleLine(p.message, 4000) ?? ''
+    const stack = asMultiLine(p.stack, 16_000)
+    const scope = asSingleLine(p.scope, 256)
+    const digest = asSingleLine(p.digest, 256)
+
+    const header = [`[${ts}]`, `[${appName}]`, level, source]
+        .concat(scope ? [scope] : [])
+        .concat(digest ? [`digest=${digest}`] : [])
+        .join(' ')
+
+    const lines: string[] = [`${header} — ${message}`]
+    if (stack) lines.push(stack)
+    const meta = safeMeta(p.meta)
+    if (meta) lines.push(`meta: ${meta}`)
+    return `${lines.join('\n')}\n\n`
+}
+
+/**
+ * Usage — `app/api/_debug-next/route.ts`:
+ * ```ts
+ * import { createDebugNextRoute } from 'debug-next/nextjs/route'
+ * export const runtime = 'nodejs'
+ * export const { POST } = createDebugNextRoute({ appName: 'dashboard' })
+ * ```
+ *
+ * ⚠️ **Do not enable this endpoint in production.** The handler accepts
+ * unauthenticated POSTs from any caller (it has to — the browser fires
+ * `window.onerror` / `unhandledrejection` without credentials) and writes
+ * the body to a local file the AI copilot reads. In production that's
+ * three problems at once:
+ *
+ *   1. **Public write surface.** Anyone on the internet can append to
+ *      your log file (up to the per-field caps in `formatClientEvent`).
+ *   2. **AI prompt-injection risk.** The file is consumed by AI sessions;
+ *      attacker-controlled text in a log they read is a real vector even
+ *      with the newline / control-char sanitization applied below.
+ *   3. **No durable value.** On Vercel/serverless the writes silently
+ *      fail anyway; on self-hosted servers the file grows unbounded.
+ *
+ * The handler short-circuits to 404 when `NODE_ENV=production` unless
+ * `DEBUG_NEXT_FORCE=true` is set — and even then you should think hard
+ * about whether you actually want this. Sentry is the right durable
+ * sink for production client errors. `debug-next` is a dev-loop tool.
+ */
+export const createDebugNextRoute = (opts: TCreateDebugNextRouteOptions) => {
+    const POST = async (request: Request): Promise<Response> => {
+        // 404 in production (or whenever writes are disabled) so the
+        // endpoint doesn't leak its existence and refuses to parse the
+        // body. See the JSDoc above for why this is intentionally strict.
+        if (isFileWritingDisabled()) {
+            return jsonResponse({ error: 'not_found' }, 404)
+        }
+
+        let body: unknown
+        try {
+            body = await request.json()
+        } catch {
+            return jsonResponse({ ok: false, error: 'invalid_json' }, 400)
+        }
+
+        const formatted = formatClientEvent(body, opts.appName)
+        if (!formatted) {
+            return jsonResponse({ ok: false, error: 'invalid_payload' }, 400)
+        }
+
+        appendRaw(formatted, opts)
+        return jsonResponse({ ok: true })
+    }
+
+    return { POST }
+}

--- a/src/nextjs/server.test.ts
+++ b/src/nextjs/server.test.ts
@@ -1,0 +1,143 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+const TMP_PREFIX = path.join(os.tmpdir(), 'debug-next-srv-')
+
+const freshTmpDir = (): string => fs.mkdtempSync(TMP_PREFIX)
+
+const readLog = (dir: string, appName: string): string =>
+    fs.readFileSync(path.join(dir, `${appName}.log`), 'utf-8')
+
+const cleanEnv = () => {
+    delete process.env.NODE_ENV
+    delete process.env.DEBUG_NEXT_DISABLE
+    delete process.env.DEBUG_NEXT_FORCE
+    delete process.env.DEBUG_NEXT_LOG_DIR
+    delete process.env.NEXT_RUNTIME
+}
+
+const reloadModule = () => {
+    jest.resetModules()
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('./server') as typeof import('./server')
+}
+
+const fakeRequest = {
+    path: '/api/checkout',
+    method: 'POST',
+    headers: { 'user-agent': 'curl' },
+}
+
+const fakeContext = {
+    routerKind: 'App',
+    routePath: '/api/checkout',
+    routeType: 'route',
+}
+
+describe('createOnRequestError', () => {
+    let logDir: string
+
+    beforeEach(() => {
+        cleanEnv()
+        logDir = freshTmpDir()
+        process.env.DEBUG_NEXT_LOG_DIR = logDir
+    })
+
+    it('writes a header + inspected error body per call', async () => {
+        const { createOnRequestError } = reloadModule()
+        const onErr = createOnRequestError({ appName: 'app' })
+        await onErr(new Error('boom'), fakeRequest, fakeContext)
+
+        const out = readLog(logDir, 'app')
+        expect(out).toMatch(
+            /^\[\d{4}-\d{2}-\d{2}T[^\]]+\] \[app\] logError route — POST \/api\/checkout$/m,
+        )
+        expect(out).toContain('Error: boom')
+    })
+
+    it('coerces non-Error throwables into an Error before logging', async () => {
+        const { createOnRequestError } = reloadModule()
+        const onErr = createOnRequestError({ appName: 'app' })
+        await onErr('plain string error', fakeRequest, fakeContext)
+
+        const out = readLog(logDir, 'app')
+        expect(out).toContain('Error: plain string error')
+    })
+
+    it('calls the optional sentry handler with the same arguments', async () => {
+        const { createOnRequestError } = reloadModule()
+        const sentry = jest.fn()
+        const onErr = createOnRequestError({ appName: 'app', sentry })
+        const err = new Error('boom')
+        await onErr(err, fakeRequest, fakeContext)
+
+        expect(sentry).toHaveBeenCalledTimes(1)
+        expect(sentry).toHaveBeenCalledWith(err, fakeRequest, fakeContext)
+    })
+
+    it('swallows errors from the sentry handler', async () => {
+        const { createOnRequestError } = reloadModule()
+        const sentry = jest.fn(() => {
+            throw new Error('sentry exploded')
+        })
+        const onErr = createOnRequestError({ appName: 'app', sentry })
+        await expect(
+            onErr(new Error('boom'), fakeRequest, fakeContext),
+        ).resolves.toBeUndefined()
+        // File write still happened despite the Sentry throw.
+        expect(readLog(logDir, 'app')).toContain('Error: boom')
+    })
+
+    it('no-ops the file write in production but still calls sentry', async () => {
+        process.env.NODE_ENV = 'production'
+        const { createOnRequestError } = reloadModule()
+        const sentry = jest.fn()
+        const onErr = createOnRequestError({ appName: 'app', sentry })
+        await onErr(new Error('boom'), fakeRequest, fakeContext)
+
+        expect(fs.existsSync(path.join(logDir, 'app.log'))).toBe(false)
+        expect(sentry).toHaveBeenCalledTimes(1)
+    })
+})
+
+describe('attachFileWriter', () => {
+    let logDir: string
+
+    beforeEach(() => {
+        cleanEnv()
+        logDir = freshTmpDir()
+        process.env.DEBUG_NEXT_LOG_DIR = logDir
+    })
+
+    it('initialises LogBase and attaches the hook so Log() calls land in the file', () => {
+        const { attachFileWriter } = reloadModule()
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { Log } = require('..') as typeof import('..')
+        attachFileWriter({ appName: 'app' })
+        const { log } = Log('arbitrary-namespace')
+        log('hello from hook')
+        const out = readLog(logDir, 'app')
+        expect(out).toContain('[app]')
+        expect(out).toContain("'hello from hook'")
+    })
+
+    it('skips attaching the hook in production, but LogBase.init still succeeds', () => {
+        process.env.NODE_ENV = 'production'
+        const { attachFileWriter } = reloadModule()
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { Log } = require('..') as typeof import('..')
+        attachFileWriter({ appName: 'app' })
+        const { log } = Log('namespace')
+        log('production silent')
+        expect(fs.existsSync(path.join(logDir, 'app.log'))).toBe(false)
+    })
+
+    it('is idempotent across repeated calls (no throw on double-init)', () => {
+        const { attachFileWriter } = reloadModule()
+        expect(() => {
+            attachFileWriter({ appName: 'app' })
+            attachFileWriter({ appName: 'app' })
+        }).not.toThrow()
+    })
+})

--- a/src/nextjs/server.ts
+++ b/src/nextjs/server.ts
@@ -61,20 +61,20 @@ export type TAttachFileWriterOptions = {
  * Idempotent: silently no-ops if `LogBase` is already initialized or
  * the hook is already attached.
  */
-export const attachFileWriter = (opts: TAttachFileWriterOptions): void => {
+export const attachFileWriter = (options: TAttachFileWriterOptions): void => {
     if (process.env.NEXT_RUNTIME === 'edge') return
 
-    if (opts.resetOnStart !== false) {
-        resetLogFile({ appName: opts.appName, logDir: opts.logDir })
+    if (options.resetOnStart !== false) {
+        resetLogFile({ appName: options.appName, logDir: options.logDir })
     }
 
-    if (opts.initLogBase !== false) {
-        const baseDir =
-            typeof opts.initLogBase === 'object'
-                ? opts.initLogBase.baseDir
+    if (options.initLogBase !== false) {
+        const baseDirectory =
+            typeof options.initLogBase === 'object'
+                ? options.initLogBase.baseDir
                 : process.cwd()
         try {
-            LogBase.init(opts.appName, baseDir)
+            LogBase.init(options.appName, baseDirectory)
         } catch {
             // already initialized
         }
@@ -86,7 +86,10 @@ export const attachFileWriter = (opts: TAttachFileWriterOptions): void => {
     // other hooks the host attaches (e.g. Sentry) still work.
     if (isFileWritingDisabled()) return
 
-    const hook = createFileWriterHook({ appName: opts.appName, logDir: opts.logDir })
+    const hook = createFileWriterHook({
+        appName: options.appName,
+        logDir: options.logDir,
+    })
     try {
         LogBase.attachHook('all', HOOK_NAME, hook)
     } catch {
@@ -129,9 +132,9 @@ const formatRequestError = (
 ): string => {
     const err = error instanceof Error ? error : new Error(String(error))
     const route = context?.routeType ?? 'route'
-    const reqLine = `${request.method ?? ''} ${request.path ?? ''}`.trim()
+    const requestLine = `${request.method ?? ''} ${request.path ?? ''}`.trim()
     const header = `[${new Date().toISOString()}] [${appName}] logError ${route} — ${
-        reqLine || '(no request)'
+        requestLine || '(no request)'
     }`
     const body = inspect(err, { depth: 4, colors: false, breakLength: 120 })
     return `${header}\n${body}\n\n`
@@ -155,17 +158,17 @@ const formatRequestError = (
  * ```
  */
 export const createOnRequestError = (
-    opts: TCreateOnRequestErrorOptions,
+    options: TCreateOnRequestErrorOptions,
 ): TOnRequestError => {
     return async (error, request, context) => {
-        appendRaw(formatRequestError(opts.appName, error, request, context), {
-            appName: opts.appName,
-            ...(opts.logDir ? { logDir: opts.logDir } : {}),
+        appendRaw(formatRequestError(options.appName, error, request, context), {
+            appName: options.appName,
+            ...(options.logDir ? { logDir: options.logDir } : {}),
         })
 
-        if (opts.sentry) {
+        if (options.sentry) {
             try {
-                await opts.sentry(error, request, context)
+                await options.sentry(error, request, context)
             } catch {
                 // never throw from instrumentation
             }

--- a/src/nextjs/server.ts
+++ b/src/nextjs/server.ts
@@ -1,0 +1,168 @@
+/**
+ * Server-side glue for hooking debug-next into a Next.js app's
+ * `instrumentation.ts`.
+ *
+ *  - `attachFileWriter`: installs the raw-line hook on the global
+ *    `LogBase`. With `resetOnStart`, also truncates the log file once
+ *    per process before appending.
+ *  - `createOnRequestError`: returns an `onRequestError` handler that
+ *    appends a terminal-style block per server error and optionally
+ *    forwards to Sentry.
+ *
+ * File writes live in `./file-writer.ts`. This module just wires them
+ * to Next.js's instrumentation surfaces.
+ */
+
+import { inspect } from 'util'
+import { LogBase } from '../index'
+import {
+    appendRaw,
+    createFileWriterHook,
+    isFileWritingDisabled,
+    resetLogFile,
+    resolveLogDir,
+    teeStdStreams,
+    type TFileWriterOptions,
+    type TTeeStdStreamsOptions,
+} from './file-writer'
+
+export { appendRaw, createFileWriterHook, resetLogFile, resolveLogDir, teeStdStreams }
+export type { TFileWriterOptions, TTeeStdStreamsOptions }
+
+const HOOK_NAME = 'debug-next/fileWriter'
+
+export type TAttachFileWriterOptions = {
+    appName: string
+    logDir?: string
+    /**
+     * Controls whether `LogBase.init()` is called. Pass `false` when the
+     * host has already initialized LogBase (e.g. an Express app already
+     * using debug-next). Pass an object to override `baseDir`.
+     */
+    initLogBase?: boolean | { baseDir: string }
+    /**
+     * Truncate `<appName>.log` once at process startup so each restart
+     * begins with a clean view. Defaults to `true`. Idempotent across
+     * hot reloads within the same process (a module-level Set prevents
+     * mid-session events from being wiped). Pass `false` to keep
+     * history across restarts.
+     */
+    resetOnStart?: boolean
+}
+
+/**
+ * Install the raw-line file-writer hook on the global `LogBase`.
+ * Idempotent: silently no-ops if `LogBase` is already initialized or
+ * the hook is already attached.
+ */
+export const attachFileWriter = (opts: TAttachFileWriterOptions): void => {
+    if (process.env.NEXT_RUNTIME === 'edge') return
+
+    if (opts.resetOnStart !== false) {
+        resetLogFile({ appName: opts.appName, logDir: opts.logDir })
+    }
+
+    if (opts.initLogBase !== false) {
+        const baseDir =
+            typeof opts.initLogBase === 'object'
+                ? opts.initLogBase.baseDir
+                : process.cwd()
+        try {
+            LogBase.init(opts.appName, baseDir)
+        } catch {
+            // already initialized
+        }
+    }
+
+    // When file writes are disabled (prod by default, or DEBUG_NEXT_DISABLE),
+    // skip attaching the hook so it doesn't fire on every Log() call only to
+    // no-op inside appendRaw. LogBase.init above is preserved either way so
+    // other hooks the host attaches (e.g. Sentry) still work.
+    if (isFileWritingDisabled()) return
+
+    const hook = createFileWriterHook({ appName: opts.appName, logDir: opts.logDir })
+    try {
+        LogBase.attachHook('all', HOOK_NAME, hook)
+    } catch {
+        // hook already attached
+    }
+}
+
+type TNextRequestLike = {
+    path: string
+    method: string
+    headers: Record<string, string | string[] | undefined>
+}
+
+type TNextRouteContext = {
+    routerKind: string
+    routePath: string
+    routeType: string
+    renderSource?: string
+    revalidateReason?: string
+}
+
+type TOnRequestError = (
+    error: unknown,
+    request: TNextRequestLike,
+    context: TNextRouteContext,
+) => void | Promise<void>
+
+export type TCreateOnRequestErrorOptions = {
+    appName: string
+    logDir?: string
+    /** Existing Sentry handler to compose with (e.g. `Sentry.captureRequestError`). */
+    sentry?: TOnRequestError
+}
+
+const formatRequestError = (
+    appName: string,
+    error: unknown,
+    request: TNextRequestLike,
+    context: TNextRouteContext,
+): string => {
+    const err = error instanceof Error ? error : new Error(String(error))
+    const route = context?.routeType ?? 'route'
+    const reqLine = `${request.method ?? ''} ${request.path ?? ''}`.trim()
+    const header = `[${new Date().toISOString()}] [${appName}] logError ${route} — ${
+        reqLine || '(no request)'
+    }`
+    const body = inspect(err, { depth: 4, colors: false, breakLength: 120 })
+    return `${header}\n${body}\n\n`
+}
+
+/**
+ * Build a Next.js `onRequestError` handler that appends a
+ * terminal-style block per server error to `<appName>.log` and, if
+ * configured, also calls the supplied Sentry handler. Failures in the
+ * Sentry handler are swallowed — Next.js's error path must never throw.
+ *
+ * Usage in `instrumentation.ts`:
+ * ```ts
+ * import * as Sentry from '@sentry/nextjs'
+ * import { createOnRequestError } from 'debug-next/nextjs'
+ *
+ * export const onRequestError = createOnRequestError({
+ *     appName: 'dashboard',
+ *     sentry: Sentry.captureRequestError,
+ * })
+ * ```
+ */
+export const createOnRequestError = (
+    opts: TCreateOnRequestErrorOptions,
+): TOnRequestError => {
+    return async (error, request, context) => {
+        appendRaw(formatRequestError(opts.appName, error, request, context), {
+            appName: opts.appName,
+            ...(opts.logDir ? { logDir: opts.logDir } : {}),
+        })
+
+        if (opts.sentry) {
+            try {
+                await opts.sentry(error, request, context)
+            } catch {
+                // never throw from instrumentation
+            }
+        }
+    }
+}

--- a/src/nextjs/server.ts
+++ b/src/nextjs/server.ts
@@ -21,13 +21,19 @@ import {
     isFileWritingDisabled,
     resetLogFile,
     resolveLogDir,
-    teeStdStreams,
+    pipeStdStreamsToFile,
     type TFileWriterOptions,
-    type TTeeStdStreamsOptions,
+    type TPipeStdStreamsToFileOptions,
 } from './file-writer'
 
-export { appendRaw, createFileWriterHook, resetLogFile, resolveLogDir, teeStdStreams }
-export type { TFileWriterOptions, TTeeStdStreamsOptions }
+export {
+    appendRaw,
+    createFileWriterHook,
+    resetLogFile,
+    resolveLogDir,
+    pipeStdStreamsToFile,
+}
+export type { TFileWriterOptions, TPipeStdStreamsToFileOptions }
 
 const HOOK_NAME = 'debug-next/fileWriter'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,7 +58,8 @@
         // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
         "typeRoots": ["node_modules/@types", "src/types"],
         /* List of folders to include type definitions from. */
-        // "types": [],                                 /* Type declaration files to be included in compilation. */
+        "types": ["node", "jest"],
+        /* Type declaration files to be included in compilation. */
         // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
         "esModuleInterop": true,
         /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */


### PR DESCRIPTION
Adds a `debug-next/nextjs` subpath + `debug-next-dev` CLI that capture errors from every Next.js error surface (server runtime, client runtime, React boundary, dev-server output) into `<repo-root>/.debug-next/<app>.log` — a timestamped mirror of the developer's terminal that AI copilots can read.

### Public surface

| Export | Use |
|---|---|
| `attachFileWriter` | `LogBase` hook → one stamped line per `Log()` call |
| `pipeStdStreamsToFile` | Wrap `process.stdout` / `stderr` so the file mirrors the terminal verbatim (Express morgan, `console.log`, native stacks, Snag breadcrumbs) |
| `createOnRequestError` | Drop-in for `instrumentation.ts#onRequestError`, composable with Sentry |
| `registerClientCapture` / `reportClientEvent` | Browser-side listeners + manual reporter |
| `createDebugNextRoute` | App Router POST handler that receives client posts |
| `debug-next-dev` CLI | `debug-next-dev -- next dev` wrapper |

### Production safety

`debug-next/nextjs` is a **dev-loop tool**. Every write surface short-circuits when `NODE_ENV=production`:

- `attachFileWriter` runs `LogBase.init` but skips the hook
- `pipeStdStreamsToFile` early-returns before wrapping the streams
- `createOnRequestError` no-ops the file write (Sentry composition still fires)
- `createDebugNextRoute` POST **returns 404** before parsing the body — the route doesn't leak its existence
- `registerClientCapture` early-returns in the browser so no client POSTs are fired

Opt back in for self-hosted prod servers via `DEBUG_NEXT_FORCE=true`; the README has a four-paragraph warning explaining why you probably shouldn't.

### Sanitization

The client POST route strips ASCII control characters and collapses newlines in single-line fields so an attacker can't inject a forged `[ts] [app] FORGED LINE` entry into a file the AI session reads. Multi-line `stack` keeps its newlines; everything else is stamped onto one line.

### Other bits

- Core is now browser-safe (`process.stdout.write` + `process.versions.bun` runtime-checked)
- Bumps to **0.5.0**. Exports map covers root + `./nextjs[/{client,route}]` + a `./nextjs/*` pattern fallback + `./dist/*` passthrough so bundlers that struggle with multi-condition entries still resolve subpaths
- `typesVersions` for subpath IntelliSense

### Tested

62 tests pass (20 existing + 42 new across `file-writer.test.ts`, `route.test.ts`, `server.test.ts`). Covers the `isFileWritingDisabled` env matrix, route sanitization (newline collapse, control-char strip, meta size cap), the `pipeStdStreamsToFile` line buffer + force-flush, Snag-style error inspection, and Sentry composition error swallowing.

Verified live against Next.js 16 + Turbopack and Express + `bun --hot`.

### Setup

See the README's **Next.js** section — five wiring points (instrumentation, instrumentation-client, route, global-error, dev script).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213591553128755
  - https://app.asana.com/0/0/1215118763923313