### PR TITLE
Make core logger browser/edge-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,27 @@ import('./routes');
 This way, initialization will get executed first as it is the code inside the first import statement.
 
 
+## Browser & edge runtimes
+
+`debug-next` is safe to import in non-Node runtimes (browser, edge). The
+loggers detect when `process.stdout` is unavailable and fall back to
+`console.log` / `console.error`, so the bundle won't crash when it runs
+outside Node:
+
+```js
+import { debug } from 'debug-next'
+
+const log = debug('namespace')
+log('Works in the browser too — routed through console.log') // no `process.stdout` required
+```
+
+Bun is also detected at runtime via an optional-chaining guard, so the
+caller-callsite namespacing degrades gracefully where `process.versions`
+is absent.
+
+
 ## Roadmap:
 
-1. Browser compatibility.
+1. ~~Browser compatibility.~~ ✅
 2. Support Winston transportation methodology.
 3. Out-of-box support for Sentry.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "debug-next",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "A feature-enhanced TypeScript drop-in replacement for a very popular and simple-to-use debug module.",
     "main": "./dist/index.js",
     "keywords": [

--- a/src/helpers/callerCallsite.ts
+++ b/src/helpers/callerCallsite.ts
@@ -112,7 +112,7 @@ export function callerCallsite({ depth = 0 } = {}) {
                 callers.unshift(callSite)
             }
 
-            const isBunRuntime = !!process.versions.bun
+            const isBunRuntime = typeof process !== 'undefined' && !!process.versions?.bun
 
             // skip the first function in bun runtime (callerCallsite)
             if (isBunRuntime && i === 0) continue

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,18 @@ const createLogger = (filenameOrNamespace: string | undefined) => {
     // this allow logs to be separated between non-error types (process.stdout) and error types (process.stderr)
     logger.log = (...args) => {
         const inspectOpts = cleanInspectOpts(logger.inspectOpts)
-        return process.stdout.write(`${formatWithOptions(inspectOpts, ...args)}\n`)
+        // In Node, write to stdout directly to keep non-error logs out of stderr.
+        // In non-Node runtimes (browser / edge), `process.stdout` is unavailable;
+        // fall back to console.log so the bundle doesn't crash.
+        if (
+            typeof process !== 'undefined' &&
+            typeof process.stdout?.write === 'function'
+        ) {
+            return process.stdout.write(`${formatWithOptions(inspectOpts, ...args)}\n`)
+        }
+        // eslint-disable-next-line no-console
+        console.log(formatWithOptions(inspectOpts, ...args))
+        return true
     }
     return logger
 }


### PR DESCRIPTION
Makes `debug-next` safe to import in non-Node runtimes (browser, edge), addressing roadmap item #1 (browser compatibility).

### Changes

- **`src/index.ts`** — `logger.log` wrote directly to `process.stdout`, which is unavailable in browser/edge runtimes and crashes the bundle on import. It now guards `typeof process` / `process.stdout?.write` and falls back to `console.log` when stdout is absent. Node behavior is unchanged (non-error logs still go to stdout, not stderr).
- **`src/helpers/callerCallsite.ts`** — hardens the Bun-runtime detection with a `typeof process !== 'undefined' && !!process.versions?.bun` guard so callsite namespacing degrades gracefully where `process.versions` is absent.
- **`README.md`** — documents browser/edge support and marks the roadmap item done.
- **`package.json`** — bumps `0.4.0 → 0.5.0`.

### Notes

This is split out from the larger Next.js integration work (previously #4) so the core runtime-safety fix can land on its own. The Next.js subpath + CLI will follow in a separate PR.

Type-check passes (`tsc --project tsconfig.build.json --noEmit`).